### PR TITLE
Avoid unnecessary boxing

### DIFF
--- a/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/bridgemgr/BridgeAdmin.java
+++ b/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/bridgemgr/BridgeAdmin.java
@@ -268,7 +268,7 @@ public class BridgeAdmin extends BrokerAdminConn {
                 mesg.setStringProperty(AdminMessageType.PropName.LINK_NAME, linkName);
             }
             if (debugMode) {
-                mesg.setBooleanProperty(AdminMessageType.PropName.DEBUG, Boolean.valueOf(debugMode));
+                mesg.setBooleanProperty(AdminMessageType.PropName.DEBUG, debugMode);
             }
             Locale locale = Locale.getDefault();
             mesg.setStringProperty(AdminMessageType.PropName.LOCALE_LANG, locale.getLanguage());

--- a/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/handlers/StartHandler.java
+++ b/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/handlers/StartHandler.java
@@ -60,7 +60,7 @@ public class StartHandler extends AdminCmdHandler {
                 throw new BridgeException(_bmr.getKString(_bmr.E_ADMIN_INVALID_LINK_NAME, lname));
             }
             if (!_bsm.startBridge(bname, new String[] { "-ln", lname }, btype)) {
-                reply.setBooleanProperty(AdminMessageType.PropName.ASYNC_STARTED, Boolean.valueOf(true));
+                reply.setBooleanProperty(AdminMessageType.PropName.ASYNC_STARTED, true);
             }
             parent.sendReply(session, msg, reply, Status.OK, (String) null, bmr);
             return;
@@ -74,7 +74,7 @@ public class StartHandler extends AdminCmdHandler {
             throw new BridgeException(_bmr.getKString(_bmr.E_ADMIN_INVALID_BRIDGE_NAME, bname));
         }
         if (!_bsm.startBridge(bname, null, btype)) {
-            reply.setBooleanProperty(AdminMessageType.PropName.ASYNC_STARTED, Boolean.valueOf(true));
+            reply.setBooleanProperty(AdminMessageType.PropName.ASYNC_STARTED, true);
         }
         parent.sendReply(session, msg, reply, Status.OK, (String) null, bmr);
         return;

--- a/mq/main/bridge/bridge-jms/src/main/java/com/sun/messaging/bridge/service/jms/DMQ.java
+++ b/mq/main/bridge/bridge-jms/src/main/java/com/sun/messaging/bridge/service/jms/DMQ.java
@@ -323,7 +323,7 @@ public class DMQ {
         }
         if (timestamp != 0) {
             try {
-                om.setLongProperty(DMQProperty.JMS_SUN_JMSBRIDGE_SOURCE_TIMESTAMP.toString(), Long.valueOf(timestamp));
+                om.setLongProperty(DMQProperty.JMS_SUN_JMSBRIDGE_SOURCE_TIMESTAMP.toString(), timestamp);
             } catch (Exception e) {
                 _logger.log(Level.WARNING, "Exception in setting source timestamp to DMQ message from message " + m + " for link " + l, e);
             }
@@ -422,7 +422,7 @@ public class DMQ {
         }
 
         try {
-            om.setLongProperty(DMQProperty.JMS_SUN_JMSBRIDGE_DMQ_TIMESTAMP.toString(), Long.valueOf(System.currentTimeMillis()));
+            om.setLongProperty(DMQProperty.JMS_SUN_JMSBRIDGE_DMQ_TIMESTAMP.toString(), System.currentTimeMillis());
         } catch (Exception e) {
             _logger.log(Level.WARNING, "Exception in setting dmq timestamp to DMQ message for message " + m + " in " + l, e);
         }

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -751,10 +751,10 @@ public class BrokerAdmin extends BrokerAdminConn {
             mesg.setJMSReplyTo(replyQueue);
             mesg.setIntProperty(MessageType.JMQ_MESSAGE_TYPE, MessageType.GET_DESTINATIONS);
             if (showpartition) {
-                mesg.setBooleanProperty(MessageType.JMQ_SHOW_PARTITION, Boolean.valueOf(true));
+                mesg.setBooleanProperty(MessageType.JMQ_SHOW_PARTITION, true);
             }
             if (loaddestination) {
-                mesg.setBooleanProperty(MessageType.JMQ_LOAD_DESTINATION, Boolean.valueOf(true));
+                mesg.setBooleanProperty(MessageType.JMQ_LOAD_DESTINATION, true);
             }
 
             if (dstName != null) {
@@ -1889,7 +1889,7 @@ public class BrokerAdmin extends BrokerAdminConn {
             mesg.setIntProperty(MessageType.JMQ_MESSAGE_TYPE, MessageType.ROLLBACK_TRANSACTION);
             mesg.setLongProperty(MessageType.JMQ_TRANSACTION_ID, tid.longValue());
             if (processActiveConsumers) {
-                mesg.setBooleanProperty(MessageType.JMQ_PROCESS_ACTIVE_CONSUMERS, Boolean.valueOf(true));
+                mesg.setBooleanProperty(MessageType.JMQ_PROCESS_ACTIVE_CONSUMERS, true);
             }
 
             statusEvent = createStatusEvent(BrokerCmdStatusEvent.ROLLBACK_TXN, MessageType.ROLLBACK_TRANSACTION_REPLY, "ROLLBACK_TRANSACTION_REPLY");
@@ -1947,7 +1947,7 @@ public class BrokerAdmin extends BrokerAdminConn {
             mesg.setJMSReplyTo(replyQueue);
             mesg.setIntProperty(MessageType.JMQ_MESSAGE_TYPE, MessageType.GET_TRANSACTIONS);
             if (showpartition) {
-                mesg.setBooleanProperty(MessageType.JMQ_SHOW_PARTITION, Boolean.valueOf(true));
+                mesg.setBooleanProperty(MessageType.JMQ_SHOW_PARTITION, true);
             }
 
             if (tid_specified) {


### PR DESCRIPTION
Methods `set[Boolean|Long]Property` accept primitives, so such boxing is immediately undone anyway.