### PR TITLE
Site updates for 3.0-M1

### DIFF
--- a/Downloads.md
+++ b/Downloads.md
@@ -1,19 +1,23 @@
-# Downloads
+# Eclipse Open MQ Downloads
 
-The first Eclipse release of Open Message Queue is 5.1.4.
-This is release supports JMS 2.0.1.
-Eclipse Open Message Queue 5.1.4 is the JMS provider in Eclipse GlassFish Server 5.1.
+## Eclipse Open MQ 6 Prerelease Milestone
 
-## License
+A Milestone release of Open MQ is being provided for early evaluation as part of the forthcoming Jakarta EE 9 release. Eclipse GlassFish 6 implements Jakarta EE 9. More details about the changes proposed are available from the associated Specification Projects, [Jakarta EE 9](https://eclipse-ee4j.github.io/jakartaee-platform/) and [Eclipse Messaging 6](https://eclipse-ee4j.github.io/jms-api/). This version of Open MQ, like previous versions, is the Jakarta Messaging provider included in Eclipse GlassFish and is provided in the Eclipse GlassFish Platform download: 
 
-[Click here to view the license](https://github.com/eclipse-ee4j/openmq/blob/master/LICENSE.md).
+* [Eclipse GlassFish 6, Full Platform 6.0.0-M1](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.zip), - [info](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-M1.info)
 
-## Downloads
+Snapshot releases are provided as well. These are evolving continuously:
 
-### Eclipse Open MQ 5.1.4 Release
+* [Eclipse GlassFish 6, Full Platform 6.0.0-SNAPSHOT](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-SNAPSHOT-nightly.zip), - [info](http://download.eclipse.org/ee4j/glassfish/glassfish-6.0.0-SNAPSHOT-nightly.info)
 
-Eclipse Open MQ is included with Eclipse GlassFish Server, full platform. You can download Eclipse GlassFish Server [here](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip).
+We welcome your feedback! Please include the details provided in the **info** link when reporting any [issues](https://github.com/eclipse-ee4j/openmq/issues), and be sure to focus on the Jakarta Messaging and/or Open MQ specic problems. General issues related to Eclipse GlassFish can be filed [here](https://github.com/eclipse-ee4j/glassfish/issues) (and also do reference the **info** details over there, as well.
 
-### Older versions
+## Eclipse Open MQ 5.1.4 Release
+
+This is the stable, Jakarta Messaging 2 (Jakarta EE 8) release of Eclipse Open Message Queue. Open MQ is the Jakarta Messaging provider in Eclipse GlassFish Server 5.1 and is included in the Eclipse GlassFish Platform download. This release supports Jakarta Messaging 2.0.1.
+
+You may download Eclipse GlassFish Server [here](https://www.eclipse.org/downloads/download.php?file=/glassfish/glassfish-5.1.0.zip).
+
+## Older versions
 
 If you are looking for older versions of Open Message Queue, produced by Oracle, these are still are available on the legacy [Open Message Queue Downloads](https://javaee.github.io/openmq/Downloads.html) page.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
+# Eclipse Open Message Queue
+
 Welcome to the home of Eclipse Open Message Queue (Eclipse Open MQ) on GitHub.
 
-Eclipse Open Message Queue is a complete message-oriented middleware platform, offering high quality,
-enterprise-ready messaging. It is an implementation for the JMS (Java Message Service) specification,
-and the JMS provider in Eclipse GlassFish. 
+Eclipse Open MQ is a complete message-oriented middleware platform, offering high quality,
+enterprise-ready messaging. It is an implementation of the Jakarta Messaging specification (jormerly, Java Message Service),
+and the default Jakarta Messaging provider delivered with Eclipse GlassFish. 
 
-Eclipse Open Message Queue is open source, with a community of developers and users. Please see the [license](https://github.com/eclipse-ee4j/openmq/blob/master/LICENSE.md) and the [terms of use for contributors](https://github.com/eclipse-ee4j/openmq/blob/master/LICENSE.md/CONTRIBUTING.md).
+Eclipse Open MQ is open source, with a community of developers and users actively updating and using it. If you are interested in using Open MQ, you can review the [license](https://github.com/eclipse-ee4j/openmq/blob/master/LICENSE.md). If you are interested in contributing to Open MQ, please check the [terms of use for contributors](https://github.com/eclipse-ee4j/openmq/blob/master/LICENSE.md/CONTRIBUTING.md).
 
-To find out more about Open Message Queue, read the  [Quick start guide](Overview.md). 
-To obtain Open Message Queue, visit the [Downloads page](Downloads.md).
+To find out more about using Eclipse Open MQ, read the  [Quick start guide](Overview.md). 
+To obtain a copy of Eclipse Open MQ, visit the [Downloads page](Downloads.md).
 
-[TCK results summary](https://eclipse-ee4j.github.io/openmq/certifications/jakarta-messaging/2.0/TCK-Results)
+If you are interested in other Eclipse EE4J projects, browse to the [EE4J Working Group page](https://projects.eclipse.org/projects/ee4j). Additional details for Eclipse Open MQ can be found on its [EE4J.OpenMQ page](https://projects.eclipse.org/projects/ee4j.openmq).
+
+As part of the Jakarta EE certification, we provide our completed TCK results
+
+Jakarta EE 9
+* Work in Progress
+
+Jakarta EE 8
+* [TCK results summary](https://eclipse-ee4j.github.io/openmq/certifications/jakarta-messaging/2.0/TCK-Results)

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: [Eclipse Open Message Queue (Eclipse Open MQ) -- A complete JMS MOM
 # sidebar links url
 links:
   source: https://github.com/eclipse-ee4j/openmq
-  download: https://projects.eclipse.org/projects/ee4j.glassfish/downloads
+  download: downloads
   mailinglist: https://accounts.eclipse.org/mailing-list/openmq-dev
   #javadocs:
   docs: https://eclipse-ee4j.github.io/openmq/guides/

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ description: [Eclipse Open Message Queue (Eclipse Open MQ) -- A complete JMS MOM
 # sidebar links url
 links:
   source: https://github.com/eclipse-ee4j/openmq
-  download: downloads
+  download: Downloads
   mailinglist: https://accounts.eclipse.org/mailing-list/openmq-dev
   #javadocs:
   docs: https://eclipse-ee4j.github.io/openmq/guides/


### PR DESCRIPTION
Jakartified home page
Added download links for 3.0.0-M1
Fixed the download link in the RH menu to point to the local page.
Changes can be previewed on my fork: https://edbratt.github.io/openmq/