### PR TITLE
Display JMS API in Admin Console

### DIFF
--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -83,7 +83,7 @@
                                         <filter token="MINOR_VERSION" value="${minor.version}" />
                                         <filter token="MICRO_VERSION" value="${micro.version}" />
                                         <filter token="PRODUCT_VERSION" value="${major.version}.${minor.version}.${micro.version}" />
-                                        <filter token="JMS_VERSION" value="${javax-jms.version}" />
+                                        <filter token="JMS_VERSION" value="${jakarta-jms.version}" />
                                         <filter token="PRODUCT_NAME" value="${product.name}" />
                                         <filter token="PRODUCT_ABBREVNAME" value="${product.abbrevname}" />
                                         <filter token="DATE" value="${TODAY} ${TSTAMP}" />

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -63,6 +63,7 @@
         <!-- Versions of dependencies -->
         <asm.version>7.3.1</asm.version>
         <hk2.version>2.6.1</hk2.version>
+        <jakarta-jms.version>3.0.0-RC1</jakarta-jms.version>
         <hk2.plugin.version>2.6.1</hk2.plugin.version>
 
         <grizzly.version>2.4.4</grizzly.version>
@@ -115,7 +116,7 @@
             <dependency>
                 <groupId>jakarta.jms</groupId>
                 <artifactId>jakarta.jms-api</artifactId>
-                <version>3.0.0-RC1</version>
+                <version>${jakarta-jms.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.resource</groupId>


### PR DESCRIPTION
With this fix following is presented:
![openmq-jms-api-version-after](https://user-images.githubusercontent.com/11896137/87221971-4f280e00-c370-11ea-9829-20089f87a91f.png)

Fixes #535