### PR TITLE
Use properties defined in parent

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -436,8 +436,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
                         <compilerArgument>-Xlint:unchecked</compilerArgument>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
#512 introduced properties to set source/target in maven-compiler-plugin.
I propose to remove this override in plugin (or in other case - to remove unused properties).