### PR TITLE
UTs for MultiColumnPrinter

### DIFF
--- a/mq/main/comm-util/src/main/java/com/sun/messaging/jmq/util/MultiColumnPrinter.java
+++ b/mq/main/comm-util/src/main/java/com/sun/messaging/jmq/util/MultiColumnPrinter.java
@@ -231,6 +231,7 @@ public abstract class MultiColumnPrinter implements Serializable {
      */
     public void setNumCol(int n) {
         numCol = n;
+        curLength = new int[numCol];
     }
 
     public void setGap(int n) {

--- a/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
+++ b/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
@@ -71,4 +71,18 @@ class MultiColumnPrinterTest {
         assertThat(printedOutput).isEqualTo("E         " + SYSTEM_LINE_SEPARATOR + "m    q" + SYSTEM_LINE_SEPARATOR
                 + "M    Q" + SYSTEM_LINE_SEPARATOR);
     }
+
+    @Test
+    void testFourColumns() {
+        mcp.setNumCol(4);
+        mcp.addTitle(new String[] { "E", null, "F", null }, new int[] { 2, 0, 2, 0 });
+        mcp.addTitle(new String[] { "1", "2", "3", "4" });
+        mcp.add(new String[] { "o", "p", "e", "n" });
+
+        mcp.print();
+        String printedOutput = baos.toString();
+
+        assertThat(printedOutput).isEqualTo("E         F         " + SYSTEM_LINE_SEPARATOR + "1    2    3    4" + SYSTEM_LINE_SEPARATOR
+                + "o    p    e    n" + SYSTEM_LINE_SEPARATOR);
+    }
 }

--- a/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
+++ b/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class MultiColumnPrinterTest {
@@ -73,7 +72,6 @@ class MultiColumnPrinterTest {
                 + "M    Q" + SYSTEM_LINE_SEPARATOR);
     }
 
-    @Disabled(value = "Due to ArrayIndexOutOfBoundsException at MCP.print")
     @Test
     void testFourColumns() {
         mcp.setNumCol(4);

--- a/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
+++ b/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * package com.sun.messaging.jmq.util;
+ */
+
+package com.sun.messaging.jmq.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MultiColumnPrinterTest {
+    private static final String SYSTEM_LINE_SEPARATOR = "*";
+
+    static class TestedMultiColumnPrinter extends MultiColumnPrinter {
+        private PrintWriter out;
+
+        TestedMultiColumnPrinter(PrintWriter writer) {
+            out = writer;
+        }
+
+        @Override
+        public void doPrintln(String str) {
+            out.print(str);
+            out.print(SYSTEM_LINE_SEPARATOR);
+            out.flush();
+        }
+
+        @Override
+        public void doPrint(String str) {
+            out.print(str);
+            out.flush();
+        }
+    }
+
+    private TestedMultiColumnPrinter mcp;
+
+    private ByteArrayOutputStream baos;
+
+    @BeforeEach
+    public void setUp() {
+        baos = new ByteArrayOutputStream();
+        mcp = new TestedMultiColumnPrinter(new PrintWriter(baos));
+    }
+
+    @Test
+    void testTwoColumns() {
+        mcp.addTitle(new String[] { "E", null }, new int[] { 2, 0 });
+        mcp.addTitle(new String[] { "m", "q" });
+        mcp.add(new String[] { "M", "Q" });
+
+        mcp.print();
+        String printedOutput = baos.toString();
+
+        assertThat(printedOutput).isEqualTo("E         " + SYSTEM_LINE_SEPARATOR + "m    q" + SYSTEM_LINE_SEPARATOR
+                + "M    Q" + SYSTEM_LINE_SEPARATOR);
+    }
+}

--- a/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
+++ b/mq/main/comm-util/src/test/java/com/sun/messaging/jmq/util/MultiColumnPrinterTest.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class MultiColumnPrinterTest {
@@ -72,6 +73,7 @@ class MultiColumnPrinterTest {
                 + "M    Q" + SYSTEM_LINE_SEPARATOR);
     }
 
+    @Disabled(value = "Due to ArrayIndexOutOfBoundsException at MCP.print")
     @Test
     void testFourColumns() {
         mcp.setNumCol(4);

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -180,8 +180,8 @@
             <artifactId>saaj-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -83,6 +83,7 @@
         <grizzly.version>3.0.0-M1</grizzly.version>
 
         <junit.version>5.6.2</junit.version>
+        <assertj.version>3.16.1</assertj.version>
     </properties>
 
     <dependencyManagement>
@@ -396,6 +397,12 @@
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     
@@ -403,6 +410,10 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -81,6 +81,8 @@
         <hk2.plugin.version>2.6.1</hk2.plugin.version>
 
         <grizzly.version>3.0.0-M1</grizzly.version>
+
+        <junit.version>5.6.2</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -389,9 +391,9 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -399,8 +401,8 @@
     
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
All (two) calls to `setNumCol` just happen to be made with argument of `2` (which is the default value not overwritten by `BrokerCmdPrinter` nor `BridgeMgrPrinter`). So it worked by happy accident.
Thus, for now, I propose to reset `curLength`, as is done in constructor - with relation to value of `numCol` to allow usage of `setNumCol` with arguments greater than 2.