### PR TITLE
Remove glassfish-api.jar from openmq

### DIFF
--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -40,9 +41,8 @@
             <artifactId>hk2-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.main.common</groupId>
-            <artifactId>glassfish-api</artifactId>
-            <optional>true</optional>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-runlevel</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.jms</groupId>

--- a/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/BridgeServiceManagerImpl.java
+++ b/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/BridgeServiceManagerImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Services Ltd.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,7 +48,6 @@ import org.jvnet.hk2.annotations.Service;
 import org.glassfish.hk2.api.PostConstruct;
 import org.glassfish.hk2.api.PreDestroy;
 import org.glassfish.hk2.runlevel.RunLevel;
-import org.glassfish.api.StartupRunLevel;
 import jakarta.inject.Inject;
 import org.glassfish.hk2.api.ServiceLocator;
 
@@ -56,7 +56,7 @@ import org.glassfish.hk2.api.ServiceLocator;
  *
  * @author amyk
  */
-@RunLevel(StartupRunLevel.VAL + 2)
+@RunLevel(12) //Startup run level in Glassfish + 2
 @Service
 //@Singleton
 public class BridgeServiceManagerImpl extends BridgeServiceManager implements ExceptionListener, MessageListener, PostConstruct, PreDestroy {

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -182,11 +183,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.main.common</groupId>
-            <artifactId>glassfish-api</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- begin of websocket dependencies -->
@@ -669,8 +665,8 @@
                                         <include name="jakarta.jms-api.jar" />
                                         <include name="grizzly-framework.jar" />
                                         <include name="grizzly-portunif.jar" />
-                                        <include name="glassfish-api.jar" />
                                         <include name="hk2-api.jar" />
+                                        <include name="hk2-runlevel.jar" />
 
                                         <!-- begin websocket broker dependencies -->
                                         <include name="grizzly-http.jar" />

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -186,11 +187,6 @@
                 <groupId>org.glassfish.grizzly</groupId>
                 <artifactId>grizzly-portunif</artifactId>
                 <version>${grizzly.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.main.common</groupId>
-                <artifactId>glassfish-api</artifactId>
-                <version>5.1.0</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.external</groupId>

--- a/mq/src/buildant/jarrules.xml
+++ b/mq/src/buildant/jarrules.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -800,7 +801,7 @@
      <copy file="${packager.artifacts}/grizzly-portunif.jar" tofile="${classes.dir}/grizzly-portunif.jar"/>  
      <copy file="${packager.artifacts}/jakarta.transaction-api.jar" tofile="${classes.dir}/jakarta.transaction-api.jar"/>
      <copy file="${packager.artifacts}/jhall.jar" tofile="${classes.dir}/jhall.jar"/>  
-     <copy file="${packager.artifacts}/glassfish-api.jar" tofile="${classes.dir}/glassfish-api.jar"/>  
+     <copy file="${packager.artifacts}/hk2-runlevel.jar" tofile="${classes.dir}/hk2-runlevel.jar"/>  
      <copy file="${packager.artifacts}/hk2-api.jar" tofile="${classes.dir}/hk2-api.jar"/>  
      <copy file="${packager.artifacts}/grizzly-http.jar" tofile="${classes.dir}/grizzly-http.jar"/>  
      <copy file="${packager.artifacts}/grizzly-http-server.jar" tofile="${classes.dir}/grizzly-http-server.jar"/>  
@@ -839,11 +840,11 @@
      <copy file="${nucleushome}/hk2-api.jar" tofile="${classes.dir}/hk2-api.jar"/>  
    </target>
 
-  <!-- ======================== glassfish-api.jar =============================== -->
-   <target name="glassfish-apijar"
-          description="Copies the glassfish-api.jar file">
-       <echo message="Copying glassfish-api.jar"/>
-     <copy file="${nucleushome}/glassfish-api.jar" tofile="${classes.dir}/glassfish-api.jar"/>  
+  <!-- ======================== hk2-runlevel.jar =============================== -->
+   <target name="hk2-runleveljar"
+          description="Copies the hk2-runlevel.jar file">
+       <echo message="Copying hk2-runlevel.jar"/>
+     <copy file="${nucleushome}/hk2-runlevel.jar" tofile="${classes.dir}/hk2-runlevel.jar"/>  
    </target>
 
   <!-- ======================== jhall.jar =============================== -->

--- a/mq/src/buildant/jars.properties
+++ b/mq/src/buildant/jars.properties
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2010, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -43,7 +44,7 @@ mqadmin.classpath=imqutil.jar imqjmx.jar imq.jar jms.jar jhall.jar \
 #-------------
 mqbroker.classpath=imqutil.jar imqjmx.jar imq.jar jms.jar \
                  grizzly-framework.jar grizzly-portunif.jar imqstomp.jar imqjmsbridge.jar \
-                 bdb_je.jar hk2-api.jar glassfish-api.jar grizzly-http.jar grizzly-http-server.jar \
+                 bdb_je.jar hk2-api.jar hk2-runlevel.jar grizzly-http.jar grizzly-http-server.jar \
 		 grizzly-http-servlet.jar jakarta.servlet-api.jar grizzly-websockets.jar jakarta.json.jar \
                  imq_server_l10n.jar imq_server_lang1.jar
 

--- a/mq/src/buildant/rules.xml
+++ b/mq/src/buildant/rules.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2020 Payara Services Ltd.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -252,8 +253,8 @@
     <pathelement location="${packager.artifacts}/jakarta.xml.soap-api.jar"/>
     <pathelement location="${packager.artifacts}/jakarta.activation-api.jar"/>
     <pathelement location="${packager.artifacts}/jhall.jar"/>
-    <pathelement location="${packager.artifacts}/glassfish-api.jar"/>
     <pathelement location="${packager.artifacts}/hk2-api.jar"/>
+    <pathelement location="${packager.artifacts}/hk2-runlevel.jar"/>
     <pathelement location="${classes.dir}"/>
 
   </path>
@@ -725,16 +726,16 @@ All rights reserved.</i></font>]]></bottom>
 	<move file="${extjars}/${mq.bootstrap.jar5}" tofile="${extjars}/auto-depends.jar"/>
     </target>
 
-    <!-- download glassfish-api -->
+    <!-- download hk2-runlevel -->
     <target name="bootstrap6">
-        <echo message="get glassfish-api.jar from ${mq.bootstrap.url6}"/>
+        <echo message="get hk2-runlevel.jar from ${mq.bootstrap.url6}"/>
         <echo message="downloading to ${extjars}"/>
 	<mkdir dir="${extjars}"/>
         <exec executable="wget" dir="${extjars}" failonerror="true" >
 	    <arg line="--no-check-certificate" />
             <arg line="${mq.bootstrap.url6}" />
 	</exec>
-	<move file="${extjars}/${mq.bootstrap.jar6}" tofile="${extjars}/glassfish-api.jar"/>
+	<move file="${extjars}/${mq.bootstrap.jar6}" tofile="${extjars}/hk2-runlevel.jar"/>
     </target>
 
     <!-- download hk2-api -->

--- a/mq/src/solaris/bin/adminconsole.sh
+++ b/mq/src/solaris/bin/adminconsole.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -108,7 +109,7 @@ jvm_args="$jvm_args -Dimq.home=$imq_home"
 
 #_ext_classes=$imq_external/jndifs/lib/fscontext.jar:../../../../src/buildcfg/tools/ri/javahelp/jhall.jar
 
-_ext_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_ext_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 #
 # Append CLASSPATH value to _classes if it is set.
 #

--- a/mq/src/solaris/bin/bridgemgr.sh
+++ b/mq/src/solaris/bin/bridgemgr.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -117,7 +118,7 @@ jvm_args="$jvm_args -Dimq.home=$imq_home"
 #_ext_classes=$imq_external/jndifs/lib/fscontext.jar
 #_classes=$imq_home/../../share/opt/classes:$_ext_classes
 
-_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 _mainclass=com.sun.messaging.bridge.admin.bridgemgr.BridgeMgr
 

--- a/mq/src/solaris/bin/broker.sh
+++ b/mq/src/solaris/bin/broker.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -89,7 +90,7 @@ fi
 
 jvm_args="$def_jvm_args $jvm_args -Dimq.home=$imq_home"
 
-_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/grizzly-http.jar:$dependlibs/grizzly-http-server.jar:$dependlibs/grizzly-http-servlet.jar:$dependlibs/jakarta.servlet-api.jar:$dependlibs/grizzly-websockets.jar:$dependlibs/jakarta.json.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/grizzly-http.jar:$dependlibs/grizzly-http-server.jar:$dependlibs/grizzly-http-servlet.jar:$dependlibs/jakarta.servlet-api.jar:$dependlibs/grizzly-websockets.jar:$dependlibs/jakarta.json.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 # Additional classes possibly needed for JDBC provider
 _classes=$_classes:$imq_home/lib/ext

--- a/mq/src/solaris/bin/dbmgr.sh
+++ b/mq/src/solaris/bin/dbmgr.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -68,7 +69,7 @@ javacmd=$javahome/bin/$javacmd
 jvm_args="$def_jvm_args $jvm_args -Dimq.home=$imq_home"
 
 #_classes=$imq_home/../../share/opt/classes
-_classes=$imq_home/../../share/opt/classes:$dependlibs/javax.jms-api.jar:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_classes=$imq_home/../../share/opt/classes:$dependlibs/javax.jms-api.jar:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 # Additional classes possibly needed for JDBC provider
 _classes=$_classes:$imq_home/lib/ext

--- a/mq/src/solaris/bin/icmd.sh
+++ b/mq/src/solaris/bin/icmd.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -116,7 +117,7 @@ jvm_args="$jvm_args -Dimq.home=$imq_home"
 
 #_ext_classes=$imq_external/jndifs/lib/fscontext.jar
 #_classes=$imq_home/../../share/opt/classes:$_ext_classes
-_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 _mainclass=com.sun.messaging.jmq.admin.apps.broker.BrokerCmd
 

--- a/mq/src/solaris/bin/objmgr.sh
+++ b/mq/src/solaris/bin/objmgr.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -107,7 +108,7 @@ javacmd=$javahome/bin/$javacmd
 jvm_args="$jvm_args -Dimq.home=$imq_home"
 
 #_ext_classes=$imq_external/jndifs/lib/fscontext.jar
-_ext_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_ext_classes=$dependlibs/javax.jms-api.jar:$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 #
 # Append CLASSPATH value to _classes if it is set.

--- a/mq/src/solaris/bin/usermgr.sh
+++ b/mq/src/solaris/bin/usermgr.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020 Payara Services Ltd.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -106,7 +107,7 @@ javacmd=$javahome/bin/$javacmd
 jvm_args="$jvm_args -Dimq.home=$imq_home"
 
 #_classes=$imq_home/../../share/opt/classes
-_classes=$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/glassfish-api.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
+_classes=$imq_home/../../share/opt/classes:$dependlibs/grizzly-framework.jar:$dependlibs/grizzly-portunif.jar:$dependlibs/hk2-runlevel.jar:$dependlibs/hk2-api.jar:$dependlibs/jakarta.transaction-api.jar:$dependlibs/jhall.jar:$dependlibs/fscontext.jar:$dependlibs/audit.jar:$dependlibs/bdb_je.jar
 
 _mainclass=com.sun.messaging.jmq.jmsserver.auth.usermgr.UserMgr
 

--- a/mq/src/win32/bin/adminconsole.bat
+++ b/mq/src/win32/bin/adminconsole.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 "%JAVA_HOME%\bin\java" -cp %_classes% %JVM_ARGS% %_mainclass% %BKR_ARGS%
 

--- a/mq/src/win32/bin/bridgemgr.bat
+++ b/mq/src/win32/bin/bridgemgr.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 echo JAVA_HOME is %JAVA_HOME%
 echo JVM_ARGS is %JVM_ARGS%

--- a/mq/src/win32/bin/broker.bat
+++ b/mq/src/win32/bin/broker.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -50,7 +51,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\grizzly-http.jar;%DEPENDLIBS%\grizzly-http-server.jar;%DEPENDLIBS%\grizzly-http-servlet.jar;%DEPENDLIBS%\jakarta.servlet-api.jar;%DEPENDLIBS%\grizzly-websockets.jar;%DEPENDLIBS%\jakarta.json.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\grizzly-http.jar;%DEPENDLIBS%\grizzly-http-server.jar;%DEPENDLIBS%\grizzly-http-servlet.jar;%DEPENDLIBS%\jakarta.servlet-api.jar;%DEPENDLIBS%\grizzly-websockets.jar;%DEPENDLIBS%\jakarta.json.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 echo JAVA_HOME is %JAVA_HOME%
 echo JVM_ARGS is %JVM_ARGS%

--- a/mq/src/win32/bin/dbmgr.bat
+++ b/mq/src/win32/bin/dbmgr.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\javax.jms-api.jar;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\javax.jms-api.jar;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 "%JAVA_HOME%\bin\java" -cp %_classes% %JVM_ARGS% %_mainclass% %BKR_ARGS%
 

--- a/mq/src/win32/bin/icmd.bat
+++ b/mq/src/win32/bin/icmd.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 "%JAVA_HOME%\bin\java" -cp %_classes% %JVM_ARGS% %_mainclass% %BKR_ARGS%
 

--- a/mq/src/win32/bin/objmgr.bat
+++ b/mq/src/win32/bin/objmgr.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jta.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%DEPENDLIBS%\grizzly-framework.jar;%IMQ_EXTERNAL%\*
+set _classes=%DEPENDLIBS%\javax.jms-api.jar;%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jta.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%DEPENDLIBS%\grizzly-framework.jar;%IMQ_EXTERNAL%\*
 
 "%JAVA_HOME%\bin\java" -cp %_classes% %JVM_ARGS% %_mainclass% %BKR_ARGS%
 
@@ -82,8 +83,8 @@ REM
 goto resume2
 
 :noclasspath
-set _classes=%_IMQ_HOME%\..\..\share\opt\classes;%_DEPENDLIBS%\glassfish-api.jar;%_DEPENDLIBS%\grizzly-portunif.jar;%_DEPENDLIBS%\hk2.jar;%_DEPENDLIBS%\hk2-api.jar;%_DEPENDLIBS%\jhall.jar;%_DEPENDLIBS%\jta.jar;%_DEPENDLIBS%\fscontext.jar;%_DEPENDLIBS%\audit.jar;%_DEPENDLIBS%\bdb_je.jar;%_DEPENDLIBS%\grizzly-framework.jar;%CLASSPATH%
-set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%_IMQ_HOME%\..\..\share\opt\classes;%_DEPENDLIBS%\hk2-runlevel.jar;%_DEPENDLIBS%\grizzly-portunif.jar;%_DEPENDLIBS%\hk2.jar;%_DEPENDLIBS%\hk2-api.jar;%_DEPENDLIBS%\jhall.jar;%_DEPENDLIBS%\jta.jar;%_DEPENDLIBS%\fscontext.jar;%_DEPENDLIBS%\audit.jar;%_DEPENDLIBS%\bdb_je.jar;%_DEPENDLIBS%\grizzly-framework.jar;%CLASSPATH%
+set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 :resume2
 

--- a/mq/src/win32/bin/usermgr.bat
+++ b/mq/src/win32/bin/usermgr.bat
@@ -1,6 +1,7 @@
 @echo off
 REM
 REM  Copyright (c) 2000-2017 Oracle and/or its affiliates. All rights reserved.
+REM  Copyright (c) 2020 Payara Services Ltd.
 REM
 REM  This program and the accompanying materials are made available under the
 REM  terms of the Eclipse Public License v. 2.0, which is available at
@@ -49,7 +50,7 @@ FOR /f "tokens=1,2* delims= " %%a IN ("%args_list%") DO (
 if "%JAVA_HOME%" == "" (echo "Please set the JAVA_HOME environment variable or use -javahome" & goto end)
 
 set JVM_ARGS=%JVM_ARGS% -Dimq.home=%IMQ_HOME%
-set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\glassfish-api.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
+set _classes=%IMQ_HOME%\..\..\share\opt\classes;%DEPENDLIBS%\grizzly-framework.jar;%DEPENDLIBS%\grizzly-portunif.jar;%DEPENDLIBS%\hk2-runlevel.jar;%DEPENDLIBS%\hk2-api.jar;%DEPENDLIBS%\jhall.jar;%DEPENDLIBS%\jakarta.transaction-api.jar;%DEPENDLIBS%\fscontext.jar;%DEPENDLIBS%\audit.jar;%DEPENDLIBS%\bdb_je.jar;%IMQ_EXTERNAL%\*
 
 "%JAVA_HOME%\bin\java" -cp %_classes% %JVM_ARGS% %_mainclass% %BKR_ARGS%
 


### PR DESCRIPTION
This avoids any kind of circular dependency, also it was only included for a single reference to a constant.

This is an alternative to #562 
