### PR TITLE
Do not store duplicated bin/* entries in produced archive

### DIFF
--- a/mq/src/buildant/distrules.xml
+++ b/mq/src/buildant/distrules.xml
@@ -1230,7 +1230,7 @@ IMQ_DEFAULT_VARHOME=../../glassfish/domains/domain1/imq]]>
 
 
 		<delete file="${mq.bundlesdir}/mq.zip"/>
-		<zip file="${mq.bundlesdir}/mq.zip">
+		<zip file="${mq.bundlesdir}/mq.zip" duplicate="preserve">
 			<zipfileset dir="${mq.zip.installdir}/.." includes="mq/bin/**" filemode="755" />
 			<zipfileset dir="${mq.zip.installdir}/.." includes="mq/**"/>
 			<zipfileset dir="${ws.top.dir}" includes="LICENSE.md,NOTICE.md"/>


### PR DESCRIPTION
Fixes #586

- [x] verified in GF build, that `mq/bin/*` entries are still executable