### PR TITLE
Do not build unused mq${version}.zip 

### DIFF
--- a/mq/src/buildant/distrules.xml
+++ b/mq/src/buildant/distrules.xml
@@ -1215,19 +1215,7 @@ IMQ_DEFAULT_VARHOME=../../glassfish/domains/domain1/imq]]>
 	    description="Zips up the MQ bundle(s)">
 		<echo message="### Building MQ zip bundle in ${mq.bundlesdir}"/>
 
-		<delete file="${mq.bundlesdir}/mq${JMQ_MAJOR_VERSION}_${JMQ_MINOR_VERSION}_${JMQ_MICRO_VERSION}.zip"/>
 		<mkdir dir="${mq.bundlesdir}"/>
-		
-		<zip file="${mq.bundlesdir}/mq${JMQ_MAJOR_VERSION}_${JMQ_MINOR_VERSION}_${JMQ_MICRO_VERSION}.zip" duplicate="preserve">
-			<zipfileset dir="${mq.zip.installdir}/.." filemode="755" 
-	    	includes="mq/bin/**"/>
-			<zipfileset dir="${mq.zip.installdir}/.." 
-	     	includes="mq/**"/>
-		</zip>
-		<echo message="### MQ zip bundle created in ${mq.bundlesdir}/mq${JMQ_MAJOR_VERSION}_${JMQ_MINOR_VERSION}_${JMQ_MICRO_VERSION}.zip"/>
-		<echo message="### MQ zip bundle does not preserve file permissions so you must"/>
-		<echo message="### chmod 755 mq/bin/imq* after unzipping mq${JMQ_MAJOR_VERSION}_${JMQ_MINOR_VERSION}_${JMQ_MICRO_VERSION}.zip."/>
-
 
 		<delete file="${mq.bundlesdir}/mq.zip"/>
 		<zip file="${mq.bundlesdir}/mq.zip" duplicate="preserve">


### PR DESCRIPTION
Save cycles during build and disk space after.

It is mq.zip installed
```
[INFO] Installing /home/jenkins/agent/workspace/1_openmq-build-and-stage/mq/dist/bundles/mq.zip to /home/jenkins/.m2/repository/org/glassfish/mq/mq-distrib     ution/6.0.0-M1/mq-distribution-6.0.0-M1.zip
```
and staged
```
[INFO] Installing /home/jenkins/agent/workspace/1_openmq-build-and-stage/mq/dist/bundles/mq.zip to /home/jenkins/agent/workspace/1_openmq-build-and-stage/m     q/distribution/target/nexus-staging/staging/839cdc981d257/org/glassfish/mq/mq-distribution/6.0.0-M1/mq-distribution-6.0.0-M1.zip
```
by job [1_openmq-build-and-stage](https://ci.eclipse.org/openmq/job/1_openmq-build-and-stage),
as configured in
https://github.com/eclipse-ee4j/openmq/blob/4af0b1313ab8c76430573e3cf4c097887aac56ba/mq/distribution/pom.xml#L110-L118