### PR TITLE
On travis build also final deliverables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,9 @@ script:
     --show-version
     --batch-mode
     --activate-profiles staging
-    clean install
-
+    clean install &&
+  mvn --file mq/distribution
+    --no-transfer-progress
+    --batch-mode
+    --activate-profiles staging
+    source:jar install


### PR DESCRIPTION
I propose to use standalone `mq/distribution` module on travis as well.

It would serve following purposes:
- make sure it is in good, healthy condition,
- make it clear it's being used.

As [jenkins job 1_openmq-build-and-stage](https://ci.eclipse.org/openmq/job/1_openmq-build-and-stage) produces sources too, I decided to also call `source:jar` goal here.