### PR TITLE
Use pom packaging instead of default (jar)

### DIFF
--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -33,6 +33,7 @@
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
     <version>6.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
     <name>Message Queue</name>
 
     <url>https://github.com/eclipse-ee4j/openmq</url>


### PR DESCRIPTION
Do not build this (empty) project jar and sources.
Install/deploy only attached zips.