### PR TITLE
Deprecate unused constructors, fields and method

### DIFF
--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/PropertyUpdateException.java
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/config/PropertyUpdateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,25 +29,45 @@ public class PropertyUpdateException extends Exception {
      * 
      */
     private static final long serialVersionUID = -924153868265758887L;
+
+    /** @deprecated As of release 6. Will be removed without replacement in future release. */
+    @Deprecated
     public static final int Unknown = 0;
+
+    /** @deprecated As of release 6. Will be removed without replacement in future release. */
+    @Deprecated
     public static final int OutOfBounds = 1;
+
+    /** @deprecated As of release 6. Will be removed without replacement in future release. */
+    @Deprecated
     public static final int InvalidSetting = 2;
 
+    @Deprecated
     private int reason = 0;
 
     public PropertyUpdateException(String msg) {
-        this(0, msg, null);
+        this(msg, null);
     }
 
+    public PropertyUpdateException(String msg, Throwable rootcause) {
+        super(msg, rootcause);
+    }
+
+    /** @deprecated As of release 6, use {@link #PropertyUpdateException(String)} instead. */
+    @Deprecated
     public PropertyUpdateException(int reason, String msg) {
         this(0, msg, null);
     }
 
+    /** @deprecated As of release 6, use {@link #PropertyUpdateException(String, Throwable)} instead. */
+    @Deprecated
     public PropertyUpdateException(int reason, String msg, Throwable rootcause) {
         super(msg, rootcause);
         this.reason = reason;
     }
 
+    /** @deprecated As of release 6. Will be removed without replacement in future release. */
+    @Deprecated
     public int getReason() {
         return reason;
     }

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Queue.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Queue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -250,13 +250,12 @@ public class Queue extends Destination {
                 try {
                     num = Integer.parseInt(value);
                 } catch (Exception ex) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, "bad value " + value + " expected integer", ex);
+                    throw new PropertyUpdateException("bad value " + value + " expected integer", ex);
                 }
                 if (MAX_LICENSED_ACTIVE != -1 && (num == -1 || num > MAX_LICENSED_ACTIVE))
 
                 {
-                    throw new PropertyUpdateException(PropertyUpdateException.OutOfBounds,
-                            Globals.getBrokerResources().getKString(BrokerResources.E_FEATURE_UNAVAILABLE,
+                    throw new PropertyUpdateException(Globals.getBrokerResources().getKString(BrokerResources.E_FEATURE_UNAVAILABLE,
                                     Globals.getBrokerResources().getKString(BrokerResources.M_LIC_PRIMARY_CONSUMERS, String.valueOf(MAX_LICENSED_ACTIVE))));
                 }
 
@@ -265,13 +264,12 @@ public class Queue extends Destination {
                 try {
                     num = Integer.parseInt(value);
                 } catch (Exception ex) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, "bad value " + value + " expected integer", ex);
+                    throw new PropertyUpdateException("bad value " + value + " expected integer", ex);
                 }
                 if (MAX_LICENSED_BACKUP != -1 && (num == -1 || num > MAX_LICENSED_BACKUP))
 
                 {
-                    throw new PropertyUpdateException(PropertyUpdateException.OutOfBounds,
-                            Globals.getBrokerResources().getKString(BrokerResources.E_FEATURE_UNAVAILABLE,
+                    throw new PropertyUpdateException(Globals.getBrokerResources().getKString(BrokerResources.E_FEATURE_UNAVAILABLE,
                                     Globals.getBrokerResources().getKString(BrokerResources.M_LIC_FAILOVER_CONSUMERS, String.valueOf(MAX_LICENSED_BACKUP))));
                 }
 

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/PortMapper.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/PortMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -317,7 +317,7 @@ public class PortMapper implements Runnable, ConfigListener, PortMapperClientHan
             }
             mqaddr = MQAddress.getMQAddress(h, getPort());
         } catch (Exception e) {
-            throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, hostname + ": " + e.toString(), e);
+            throw new PropertyUpdateException(hostname + ": " + e.toString(), e);
         }
 
         if (hostname == null || hostname.equals(Globals.HOSTNAME_ALL) || hostname.trim().length() == 0) {
@@ -355,7 +355,7 @@ public class PortMapper implements Runnable, ConfigListener, PortMapperClientHan
                 this.bindAddr = InetAddress.getByName(hostname);
             }
         } catch (Exception e) {
-            throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, rb.getString(rb.E_BAD_HOSTNAME, hostname), e);
+            throw new PropertyUpdateException(rb.getString(rb.E_BAD_HOSTNAME, hostname), e);
         }
 
         this.hostname = hostname;
@@ -890,8 +890,7 @@ public class PortMapper implements Runnable, ConfigListener, PortMapperClientHan
                     InetAddress.getByName(value);
                 }
             } catch (Exception e) {
-                throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                        rb.getKString(rb.E_BAD_HOSTNAME_PROP, value, name) + ": " + e.toString(), e);
+                throw new PropertyUpdateException(rb.getKString(rb.E_BAD_HOSTNAME_PROP, value, name) + ": " + e.toString(), e);
             }
             return;
         }
@@ -904,7 +903,7 @@ public class PortMapper implements Runnable, ConfigListener, PortMapperClientHan
                 return;
             }
             if (n == 0) {
-                throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, rb.getString(rb.X_BAD_PROPERTY_VALUE, name + "=" + value));
+                throw new PropertyUpdateException(rb.getString(rb.X_BAD_PROPERTY_VALUE, name + "=" + value));
             }
             if (isDoBind()) {
                 // Check if we will be able to bind to this port

--- a/mq/main/mq-broker/cluster/src/main/java/com/sun/messaging/jmq/jmsserver/cluster/manager/ClusterManagerImpl.java
+++ b/mq/main/mq-broker/cluster/src/main/java/com/sun/messaging/jmq/jmsserver/cluster/manager/ClusterManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -1302,7 +1302,7 @@ public class ClusterManagerImpl implements ClusterManager, ConfigListener {
             try {
                 Integer.parseInt(value);
             } catch (NumberFormatException ex) {
-                throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, PORT_PROPERTY + " should be set to an int" + " not " + value);
+                throw new PropertyUpdateException(PORT_PROPERTY + " should be set to an int" + " not " + value);
             }
         } else if (name.equals(CLUSTER_PING_INTERVAL_PROP)) {
             try {
@@ -1311,8 +1311,7 @@ public class ClusterManagerImpl implements ClusterManager, ConfigListener {
                     throw new NumberFormatException("" + value);
                 }
             } catch (NumberFormatException ex) {
-                throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                        CLUSTER_PING_INTERVAL_PROP + " should be set to a positive int" + " not " + value);
+                throw new PropertyUpdateException(CLUSTER_PING_INTERVAL_PROP + " should be set to a positive int" + " not " + value);
             }
         } else if (name.equals(AUTOCONNECT_PROPERTY)) {
             // XXX - is there a valid value

--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/CommDBManager.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/CommDBManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -238,11 +238,10 @@ public abstract class CommDBManager {
                 try {
                     v = Long.parseLong(value);
                 } catch (Exception e) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
+                    throw new PropertyUpdateException(br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
                 }
                 if (v < 0L) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, name + "=" + value);
+                    throw new PropertyUpdateException(name + "=" + value);
                 }
             }
         }

--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/DBConnectionPool.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/comm/DBConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -115,45 +115,38 @@ public class DBConnectionPool {
                 try {
                     min = Integer.parseInt(value);
                 } catch (Exception e) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
+                    throw new PropertyUpdateException(br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
                 }
                 if (min < 1) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting, "A minimum value of 1 connection is required");
+                    throw new PropertyUpdateException("A minimum value of 1 connection is required");
                 } else if (min > maxConnections) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            "Minimum connections " + min + " is greater than maximum connections " + maxConnections);
+                    throw new PropertyUpdateException("Minimum connections " + min + " is greater than maximum connections " + maxConnections);
                 }
             } else if (name.equals(dbmgr.getJDBCPropPrefix() + MAX_CONN_PROP_SUFFIX)) {
                 int max = 0;
                 try {
                     max = Integer.parseInt(value);
                 } catch (Exception e) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
+                    throw new PropertyUpdateException(br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
                 }
                 if (max < minConnections) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            "Maximum connections " + max + " is less than minimum connections " + minConnections);
+                    throw new PropertyUpdateException("Maximum connections " + max + " is less than minimum connections " + minConnections);
                 }
             } else if (name.equals(dbmgr.getJDBCPropPrefix() + POLL_TIMEOUT_PROP_SUFFIX)) {
                 try {
                     Integer.parseInt(value);
                 } catch (Exception e) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
+                    throw new PropertyUpdateException(br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
                 }
             } else if (name.equals(dbmgr.getJDBCPropPrefix() + REAP_INTERVAL_PROP_SUFFIX)) {
                 int reaptime = 0;
                 try {
                     reaptime = Integer.parseInt(value);
                 } catch (Exception e) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
+                    throw new PropertyUpdateException(br.getString(BrokerResources.X_BAD_PROPERTY_VALUE, name + "=" + value), e);
                 }
                 if (reaptime < 60) {
-                    throw new PropertyUpdateException(PropertyUpdateException.InvalidSetting,
-                            "A minimum value of 60 seconds is required for reap time interval");
+                    throw new PropertyUpdateException("A minimum value of 60 seconds is required for reap time interval");
                 }
             }
         }


### PR DESCRIPTION
1. Most of changes - to remove unused `PropertyUpdateException.reason` and its getter.
2. Rest (class fields) - due to them being unused after 1.