### PR TITLE
Print Broker Cluster Info actually

### DIFF
--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2387,7 +2387,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printConnectionInfo(Hashtable cxnInfo) {
-        print(cxnInfo, "\tConnection Info:");
+        print(cxnInfo, "\tConnection Info:", "\t  ", "=");
     }
 
     private void printDurableInfoList(Vector v) {
@@ -2445,7 +2445,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printTxnInfo(Hashtable txnInfo) {
-        print(txnInfo, "\tTransaction Info:");
+        print(txnInfo, "\tTransaction Info:", "\t  ", "=");
     }
 
     private void printClusterList(Vector v) {
@@ -2497,17 +2497,18 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printJMXInfo(Hashtable jmxInfo) {
-        print(jmxInfo, "\tJMX Connector Info:");
+        print(jmxInfo, "\tJMX Connector Info:", "\t  ", "=");
     }
 
-    static void print(Hashtable jmxInfo, String title) {
+
+    static void print(Hashtable jmxInfo, String title, String keyValPrefix, String keyValSeparator) {
         Globals.stdOutPrintln(title);
 
         for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {
             String curPropName = (String) e.nextElement();
             Object tmpObj = jmxInfo.get(curPropName);
 
-            Globals.stdOutPrintln("\t  " + curPropName + "=" + tmpObj);
+            Globals.stdOutPrintln(keyValPrefix + curPropName + keyValSeparator + tmpObj);
         }
     }
 

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2387,18 +2387,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printConnectionInfo(Hashtable cxnInfo) {
-        Globals.stdOutPrintln("\tConnection Info:");
-
-        for (Enumeration e = cxnInfo.keys(); e.hasMoreElements();) {
-            String curPropName = (String) e.nextElement();
-            String curValue;
-            Object tmpObj;
-
-            tmpObj = cxnInfo.get(curPropName);
-            curValue = tmpObj.toString();
-
-            Globals.stdOutPrintln("\t  " + curPropName + "=" + curValue);
-        }
+        print(cxnInfo, "\tConnection Info:");
     }
 
     private void printDurableInfoList(Vector v) {

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2456,18 +2456,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printTxnInfo(Hashtable txnInfo) {
-        Globals.stdOutPrintln("\tTransaction Info:");
-
-        for (Enumeration e = txnInfo.keys(); e.hasMoreElements();) {
-            String curPropName = (String) e.nextElement();
-            String curValue;
-            Object tmpObj;
-
-            tmpObj = txnInfo.get(curPropName);
-            curValue = tmpObj.toString();
-
-            Globals.stdOutPrintln("\t  " + curPropName + "=" + curValue);
-        }
+        print(txnInfo, "\tTransaction Info:");
     }
 
     private void printClusterList(Vector v) {

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -21,6 +21,7 @@
 package com.sun.messaging.jmq.admin.bkrutil;
 
 import java.util.Vector;
+import java.util.function.Consumer;
 import java.util.Hashtable;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -2387,7 +2388,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printConnectionInfo(Hashtable cxnInfo) {
-        print(cxnInfo, "\tConnection Info:", "\t  ", "=");
+        print(cxnInfo, "\tConnection Info:", "\t  ", "=", Globals::stdOutPrintln);
     }
 
     private void printDurableInfoList(Vector v) {
@@ -2445,7 +2446,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printTxnInfo(Hashtable txnInfo) {
-        print(txnInfo, "\tTransaction Info:", "\t  ", "=");
+        print(txnInfo, "\tTransaction Info:", "\t  ", "=", Globals::stdOutPrintln);
     }
 
     private void printClusterList(Vector v) {
@@ -2497,18 +2498,17 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printJMXInfo(Hashtable jmxInfo) {
-        print(jmxInfo, "\tJMX Connector Info:", "\t  ", "=");
+        print(jmxInfo, "\tJMX Connector Info:", "\t  ", "=", Globals::stdOutPrintln);
     }
 
-
-    static void print(Hashtable jmxInfo, String title, String keyValPrefix, String keyValSeparator) {
-        Globals.stdOutPrintln(title);
+    static void print(Hashtable jmxInfo, String title, String keyValPrefix, String keyValSeparator, Consumer<String> printer) {
+        printer.accept(title);
 
         for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {
             String curPropName = (String) e.nextElement();
             Object tmpObj = jmxInfo.get(curPropName);
 
-            Globals.stdOutPrintln(keyValPrefix + curPropName + keyValSeparator + tmpObj);
+            printer.accept(keyValPrefix + curPropName + keyValSeparator + tmpObj);
         }
     }
 

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2505,13 +2505,9 @@ public class BrokerAdmin extends BrokerAdminConn {
 
         for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {
             String curPropName = (String) e.nextElement();
-            String curValue;
-            Object tmpObj;
+            Object tmpObj = jmxInfo.get(curPropName);
 
-            tmpObj = jmxInfo.get(curPropName);
-            curValue = tmpObj.toString();
-
-            Globals.stdOutPrintln("\t  " + curPropName + "=" + curValue);
+            Globals.stdOutPrintln("\t  " + curPropName + "=" + tmpObj);
         }
     }
 

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2519,11 +2519,11 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printJMXInfo(Hashtable jmxInfo) {
-        print(jmxInfo);
+        print(jmxInfo, "\tJMX Connector Info:");
     }
 
-    static void print(Hashtable jmxInfo) {
-        Globals.stdOutPrintln("\tJMX Connector Info:");
+    static void print(Hashtable jmxInfo, String title) {
+        Globals.stdOutPrintln(title);
 
         for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {
             String curPropName = (String) e.nextElement();

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2519,6 +2519,10 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printJMXInfo(Hashtable jmxInfo) {
+        print(jmxInfo);
+    }
+
+    static void print(Hashtable jmxInfo) {
         Globals.stdOutPrintln("\tJMX Connector Info:");
 
         for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2501,12 +2501,12 @@ public class BrokerAdmin extends BrokerAdminConn {
         print(jmxInfo, "\tJMX Connector Info:", "\t  ", "=", Globals::stdOutPrintln);
     }
 
-    static void print(Hashtable jmxInfo, String title, String keyValPrefix, String keyValSeparator, Consumer<String> printer) {
+    static void print(Hashtable table, String title, String keyValPrefix, String keyValSeparator, Consumer<String> printer) {
         printer.accept(title);
 
-        for (Enumeration e = jmxInfo.keys(); e.hasMoreElements();) {
+        for (Enumeration e = table.keys(); e.hasMoreElements();) {
             String curPropName = (String) e.nextElement();
-            Object tmpObj = jmxInfo.get(curPropName);
+            Object tmpObj = table.get(curPropName);
 
             printer.accept(keyValPrefix + curPropName + keyValSeparator + tmpObj);
         }

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -35,7 +35,6 @@ import com.sun.messaging.jmq.util.DestMetricsCounters;
 import com.sun.messaging.jmq.admin.event.BrokerCmdStatusEvent;
 import com.sun.messaging.jmq.admin.event.CommonCmdStatusEvent;
 import com.sun.messaging.jmq.admin.util.Globals;
-import com.sun.messaging.jms.management.server.BrokerClusterInfo;
 
 /**
  * This class provides the convenient methods for sending administration messages to the JMQ broker.
@@ -2456,12 +2455,12 @@ public class BrokerAdmin extends BrokerAdminConn {
         while (e.hasMoreElements()) {
             Object o = e.nextElement();
 
-            if (!(o instanceof BrokerClusterInfo)) {
-                Globals.stdOutPrintln("\tprintClusterList: Vector contained object of type: " + o.getClass().getName() + "(expected BrokerClusterInfo)");
+            if (!(o instanceof Hashtable)) {
+                Globals.stdOutPrintln("\tprintClusterList: Vector contained object of type: " + o.getClass().getName() + "(expected java.util.Hashtable)");
                 Globals.stdOutPrintln("\t************************");
                 return;
             }
-            BrokerClusterInfo bkrClsInfo = (BrokerClusterInfo) o;
+            Hashtable bkrClsInfo = (Hashtable) o;
 
             printBkrClsInfo(bkrClsInfo);
 
@@ -2471,7 +2470,7 @@ public class BrokerAdmin extends BrokerAdminConn {
         Globals.stdOutPrintln("\t************************");
     }
 
-    private void printBkrClsInfo(BrokerClusterInfo bkrClsInfo) {
+    private void printBkrClsInfo(Hashtable bkrClsInfo) {
         Globals.stdOutPrintln("\tBroker Cluster Info:");
     }
 

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2471,7 +2471,7 @@ public class BrokerAdmin extends BrokerAdminConn {
     }
 
     private void printBkrClsInfo(Hashtable bkrClsInfo) {
-        Globals.stdOutPrintln("\tBroker Cluster Info:");
+        print(bkrClsInfo, "\tBroker Cluster Info:", "\t  ", "=", Globals::stdOutPrintln);
     }
 
     private void printJMXList(Vector v) {

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdmin.java
@@ -2503,13 +2503,9 @@ public class BrokerAdmin extends BrokerAdminConn {
 
     static void print(Hashtable table, String title, String keyValPrefix, String keyValSeparator, Consumer<String> printer) {
         printer.accept(title);
-
-        for (Enumeration e = table.keys(); e.hasMoreElements();) {
-            String curPropName = (String) e.nextElement();
-            Object tmpObj = table.get(curPropName);
-
-            printer.accept(keyValPrefix + curPropName + keyValSeparator + tmpObj);
-        }
+        table.forEach((key, value) -> {
+            printer.accept(keyValPrefix + key + keyValSeparator + value);
+        });
     }
 
     public void setAssociatedObj(Object obj) {

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -58,7 +58,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveExpectedTitle() {
-            BrokerAdmin.print(ht);
+            BrokerAdmin.print(ht, "\tJMX Connector Info:");
 
             String printed = baos.toString();
 
@@ -67,7 +67,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveElements() {
-            BrokerAdmin.print(ht);
+            BrokerAdmin.print(ht, "Any Title Will Do");
 
             String printed = baos.toString();
 

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -18,32 +18,16 @@ package com.sun.messaging.jmq.admin.bkrutil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.util.Properties;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.sun.messaging.jmq.admin.util.Globals;
-
 class BrokerAdminTest {
     @Nested
     class PrintTest {
-        private PrintStream beforeTestOut;
-        private ByteArrayOutputStream baos;
         private Properties ht;
-
-        @BeforeEach
-        void plumbStdOut() {
-            beforeTestOut = System.out;
-            baos = new ByteArrayOutputStream();
-            PrintStream testOut = new PrintStream(baos);
-            System.setOut(testOut);
-        }
 
         @BeforeEach
         void prepareHashTable() {
@@ -52,28 +36,22 @@ class BrokerAdminTest {
             ht.setProperty("b", "2");
         }
 
-        @AfterEach
-        void restoreStdOut() throws IOException {
-            System.setOut(beforeTestOut);
-            baos.close();
-        }
-
         @Test
         void shouldHaveExpectedTitle() {
-            BrokerAdmin.print(ht, "\tExpected title:", "\t  ", "=", Globals::stdOutPrintln);
+            StringBuilder message = new StringBuilder();
 
-            String printed = baos.toString();
+            BrokerAdmin.print(ht, "\tExpected title:", "\t  ", "=", message::append);
 
-            assertThat(printed).startsWith("\tExpected title:");
+            assertThat(message).startsWith("\tExpected title:");
         }
 
         @Test
         void shouldHaveElements() {
-            BrokerAdmin.print(ht, "Any Title Will Do", "\t  ", "=", Globals::stdOutPrintln);
+            StringBuilder message = new StringBuilder();
 
-            String printed = baos.toString();
+            BrokerAdmin.print(ht, "Any Title Will Do", "\t  ", "=", message::append);
 
-            assertThat(printed).contains("\t  a=1", "\t  b=2");
+            assertThat(message).contains("\t  a=1", "\t  b=2");
         }
     }
 }

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.sun.messaging.jmq.admin.util.Globals;
+
 class BrokerAdminTest {
     @Nested
     class PrintTest {
@@ -58,7 +60,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveExpectedTitle() {
-            BrokerAdmin.print(ht, "\tJMX Connector Info:", "\t  ", "=");
+            BrokerAdmin.print(ht, "\tJMX Connector Info:", "\t  ", "=", Globals::stdOutPrintln);
 
             String printed = baos.toString();
 
@@ -67,7 +69,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveElements() {
-            BrokerAdmin.print(ht, "Any Title Will Do", "\t  ", "=");
+            BrokerAdmin.print(ht, "Any Title Will Do", "\t  ", "=", Globals::stdOutPrintln);
 
             String printed = baos.toString();
 

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -58,7 +58,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveExpectedTitle() {
-            BrokerAdmin.print(ht, "\tJMX Connector Info:");
+            BrokerAdmin.print(ht, "\tJMX Connector Info:", "\t  ", "=");
 
             String printed = baos.toString();
 
@@ -67,7 +67,7 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveElements() {
-            BrokerAdmin.print(ht, "Any Title Will Do");
+            BrokerAdmin.print(ht, "Any Title Will Do", "\t  ", "=");
 
             String printed = baos.toString();
 

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jmq.admin.bkrutil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BrokerAdminTest {
+    @Nested
+    class PrintTest {
+        private PrintStream beforeTestOut;
+        private ByteArrayOutputStream baos;
+        private Properties ht;
+
+        @BeforeEach
+        void plumbStdOut() {
+            beforeTestOut = System.out;
+            baos = new ByteArrayOutputStream();
+            PrintStream testOut = new PrintStream(baos);
+            System.setOut(testOut);
+        }
+
+        @BeforeEach
+        void prepareHashTable() {
+            ht = new Properties();
+            ht.setProperty("a", "1");
+            ht.setProperty("b", "2");
+        }
+
+        @AfterEach
+        void restoreStdOut() throws IOException {
+            System.setOut(beforeTestOut);
+            baos.close();
+        }
+
+        @Test
+        void shouldHaveExpectedTitle() {
+            BrokerAdmin.print(ht);
+
+            String printed = baos.toString();
+
+            assertThat(printed).startsWith("\tJMX Connector Info:");
+        }
+
+        @Test
+        void shouldHaveElements() {
+            BrokerAdmin.print(ht);
+
+            String printed = baos.toString();
+
+            assertThat(printed).contains("\t  a=1", "\t  b=2");
+        }
+    }
+}

--- a/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
+++ b/mq/main/mq-admin/admin-cli/src/test/java/com/sun/messaging/jmq/admin/bkrutil/BrokerAdminTest.java
@@ -60,11 +60,11 @@ class BrokerAdminTest {
 
         @Test
         void shouldHaveExpectedTitle() {
-            BrokerAdmin.print(ht, "\tJMX Connector Info:", "\t  ", "=", Globals::stdOutPrintln);
+            BrokerAdmin.print(ht, "\tExpected title:", "\t  ", "=", Globals::stdOutPrintln);
 
             String printed = baos.toString();
 
-            assertThat(printed).startsWith("\tJMX Connector Info:");
+            assertThat(printed).startsWith("\tExpected title:");
         }
 
         @Test


### PR DESCRIPTION
Assuming fix proposed in #598 is in place, following is displayed:
```
$ imqcmd list bkr
Listing all the brokers in the cluster that the following broker is a member of:
...
	************************
	Broker Cluster Info:
	************************
...
```

With this modification it changes to:
```
$ imqcmd list bkr
Listing all the brokers in the cluster that the following broker is a member of:
...
	************************
	Broker Cluster Info:
		ID => 
		Address => 192.168.7.120:7676
		Version => 0
		State => 0
	************************
...
```
which I believe was originally intended.