### PR TITLE
Do not swallow InterruptedException

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ReceiveQueue.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ReceiveQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -77,6 +77,7 @@ class ReceiveQueue extends SessionQueue {
                     }
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
             }
         }
 
@@ -151,7 +152,7 @@ class ReceiveQueue extends SessionQueue {
                 wait();
             }
         } catch (InterruptedException e) {
-            
+           Thread.currentThread().interrupt();
         }
 
     }


### PR DESCRIPTION
It fixes #135, however there are few other places left where handling `InterruptedException` could be corrected.