### PR TITLE
Remove unused org.ow2.asm:* dependencies

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -104,32 +104,6 @@
                 <artifactId>osgi-resource-locator</artifactId>
                 <version>1.0.1</version>
             </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-analysis</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-commons</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-tree</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-util</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-
 
             <!-- Jakarta EE -->
             <dependency>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -76,7 +76,6 @@
         <product.copyright>Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.</product.copyright>
 
         <!-- Versions of dependencies -->
-        <asm.version>7.3.1</asm.version>
         <hk2.version>3.0.0-RC1</hk2.version>
         <jakarta-jms.version>3.0.0</jakarta-jms.version>
         <hk2.plugin.version>3.0.0-RC1</hk2.plugin.version>


### PR DESCRIPTION
With https://github.com/eclipse-ee4j/glassfish-hk2/pull/520 included in [glassfish-hk2:3.0.0-RC1](https://github.com/eclipse-ee4j/glassfish-hk2/releases/tag/3.0.0-RC1) managing `org.ow2.asm:*` is no longer needed, as they are imported from `org.glassfish.hk2:hk2-bom` and are not used in OpenMQ directly.

In the effect we no longer need `asm.version` property.