### PR TITLE
Add Dockerfile for openmq-cpp-dev container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020 Contributors to Eclipse Foundation. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+language: ruby
+
+services:
+  - docker
+
+script:
+  - docker build -t openmq-cpp-dev:test openmq-cpp-dev
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,4 @@
+Containers::
+
+- openmq-cpp-dev - it is used to build OpenMQ parts
+

--- a/openmq-cpp-dev/Dockerfile
+++ b/openmq-cpp-dev/Dockerfile
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Contributors to Eclipse Foundation. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0, which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the
+# Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+# version 2 with the GNU Classpath Exception, which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#
+
+FROM alpine
+

--- a/openmq-cpp-dev/Dockerfile
+++ b/openmq-cpp-dev/Dockerfile
@@ -16,3 +16,11 @@
 
 FROM alpine
 
+RUN apk update && \
+    apk upgrade && \
+    apk add g++ && \
+    apk add openjdk8 && \
+    apk add nspr-dev && \
+    apk add nss-dev && \
+    apk add apache-ant
+

--- a/openmq-cpp-dev/Dockerfile
+++ b/openmq-cpp-dev/Dockerfile
@@ -14,7 +14,7 @@
 # SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 #
 
-FROM alpine
+FROM alpine:3.12
 
 RUN apk update && \
     apk upgrade && \


### PR DESCRIPTION
CBI [currently does not support building docker images](https://wiki.eclipse.org/Jenkins#I_want_to_build_a_custom_Docker_image_.28with_docker_build.29.2C_but_it_does_not_work._What_should_I_do.3F) - hence travis is used to test Dockerfile' condition.