### PR TITLE
Override issueManagement inherited from parent

### DIFF
--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -49,6 +49,11 @@
         <tag>HEAD</tag>
     </scm>
 
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/eclipse-ee4j/openmq/issues</url>
+    </issueManagement>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         


### PR DESCRIPTION
Otherwise, for example at [sonarcloud](https://sonarcloud.io/dashboard?id=org.eclipse.ee4j_openmq) `https://github.com/eclipse-ee4j/ee4j/issues` is used for Bug Tracker link.