### PR TITLE
Bump maven-deploy-plugin from 2.7 to 3.0.0-M1 in /mq

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -602,7 +602,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Replaces https://github.com/eclipse-ee4j/openmq/pull/720