### PR TITLE
Use surefire's defaults

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -516,7 +516,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.0.0-M5</version>
                     <configuration>
-                        <forkCount>0</forkCount>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Avoid build warning:
```
 useSystemClassLoader setting has no effect when not forking
 The parameter forkCount should likely not be 0, not forking a JVM for tests
 reduce test accuracy, ensure to have a <forkCount> >= 1.
```