### PR TITLE
Remove documentation for REAP_TIME column

### DIFF
--- a/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/VersionDAO.java
+++ b/mq/main/mq-broker/persist-jdbc/src/main/java/com/sun/messaging/jmq/jmsserver/persist/jdbc/VersionDAO.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,12 +34,9 @@ public interface VersionDAO extends BaseDAO {
     /**
      * Version table: Version information about the current store.
      *
-     * CREATE TABLE MQVER<schemaVersion>[C<clusterID>|S<brokerID>] ( STORE_VERSION INTEGER NOT NULL, LOCK_ID VARCHAR(100),
-     * REAP_TIME BIGINT );
+     * CREATE TABLE MQVER<schemaVersion>[C<clusterID>|S<brokerID>] ( STORE_VERSION INTEGER NOT NULL, LOCK_ID VARCHAR(100));
      *
-     * STORE_VERSION - Version of this store LOCK_ID - Identifier of the broker or imqdbmgr that is currently using the
-     * store REAP_TIME - Minimum time that a broker will maintain resources from a failed broker to allow for clients to
-     * reconnect. After this time has expired, temporary destinations and other information may be reaped from the system.
+     * STORE_VERSION - Version of this store LOCK_ID - Identifier of the broker or imqdbmgr that is currently using the store
      */
     public static final String TABLE = "MQVER";
     public static final String TABLE_NAME_PREFIX = TABLE + DBConstants.SCHEMA_VERSION;


### PR DESCRIPTION
It is not used in the code. Seems to be so since v4.
None of currently supported vendors creates table with such column.