### PR TITLE
Remove documentation about bundled Java runtime

### DIFF
--- a/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/bridgemgr/resources/BridgeAdminResources.properties
+++ b/mq/main/bridge/bridge-admin/src/main/java/com/sun/messaging/bridge/admin/bridgemgr/resources/BridgeAdminResources.properties
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,7 +68,6 @@ BA1002=imqbridgemgr options:\n\
 \    -h, -help       : Display usage help.\n\
 \    -H, -Help       : Display usage help, attribute list, and examples.\n\
 \    -javahome       : Specify an alternate Java 2 compatible runtime to use.\n\
-\                      Default is to use the bundled runtime.\n\
 \    -ln             : Specify the link name.\n\
 \    -passfile       : Specify a file containing the administrator password.\n\
 \    -rtm            : Specify the receive timeout in seconds. Default is 10.\n\

--- a/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/resources/AdminResources.properties
+++ b/mq/main/mq-admin/admin-cli/src/main/java/com/sun/messaging/jmq/admin/resources/AdminResources.properties
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2020 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -99,7 +99,6 @@ A1052=imqobjmgr options:\n\
 \                   object to the service provider; this must\n\
 \                   be a unique name.\n\
 \    -javahome    : Specify an alternate Java 2 compatible runtime to use.\n\
-\                   Default is to use the bundled runtime.\n\
 \    -o           : Specify object attributes.\n\
 \    -pre         : Preview mode.  Show what will be done without doing\n\
 \                   it.\n\
@@ -317,7 +316,6 @@ A1152=imqcmd options:\n\
 \    -H, -Help       : Display usage help, attribute list, and examples.\n\
 \    -int            : Specify interval in seconds for displaying metrics.\n\
 \    -javahome       : Specify an alternate Java 2 compatible runtime to use.\n\
-\                      Default is to use the bundled runtime.\n\
 \    -m              : Specify the type of metric information to display.\n\
 \                      Valid values for broker/service metrics = {cxn, rts, ttl}.\n\
 \                      Valid values for destination metrics = {con, dsk, rts, ttl}.\n\

--- a/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/resources/BrokerResources.properties
+++ b/mq/main/mq-broker/broker-comm/src/main/java/com/sun/messaging/jmq/jmsserver/resources/BrokerResources.properties
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -73,7 +74,7 @@ B0002=usage: imqbrokerd [-D<property>=<value>]\n\
 \ -force        Perform action without user confirmation.\n\
 \ -h            displays usage information.\n\
 \ -javahome     Specify an alternate Java runtime to use. <javahome> is the\n\
-\               path to a Java 2 JDK. Default is to use the bundled runtime.\n\
+\               path to a Java 2 JDK.\n\
 \ -jrehome      Same as -javahome except <jrehome> is the path to a Java 2 JRE\n\
 \ -loglevel     Set the logging level to <level>. <level> must be one of\n\
 \               NONE, ERROR, WARNING, INFO, DEBUG, DEBUGMED, DEBUGHIGH.\n\


### PR DESCRIPTION
OpenMQ distribution does not include Java runtime now.