### PR TITLE
Silence warning from m-bundle-p

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -639,6 +639,7 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
+                    <noWarningProjectTypes>pom</noWarningProjectTypes>
                     <!-- By default, we don't export anything. -->
                     <Export-Package></Export-Package>
                     <instructions>


### PR DESCRIPTION
Avoid
```
[INFO] --- maven-bundle-plugin:5.1.2:manifest (bundle-manifest) @ mq ---
[WARNING] Ignoring project type pom - supportedProjectTypes = [jar, bundle]
```