### PR TITLE
Undeprecate JAXMServlet and move it to examples

### DIFF
--- a/mq/src/buildant/rules.xml
+++ b/mq/src/buildant/rules.xml
@@ -257,6 +257,7 @@
     <pathelement location="${packager.artifacts}/mqbridge-api.jar"/>
     <pathelement location="${packager.artifacts}/mqjaxm-api.jar"/>
     <pathelement location="${packager.artifacts}/mq-ums.jar"/>
+    <pathelement location="${packager.artifacts}/mqcomm-util.jar"/>
 
   </path>
   <!-- ================= General initialization ======================== -->

--- a/mq/src/share/java/examples/jaxm/JAXMServlet.java
+++ b/mq/src/share/java/examples/jaxm/JAXMServlet.java
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package jakarta.xml.messaging;
-
 import jakarta.xml.soap.*;
 
 import jakarta.servlet.*;
@@ -42,9 +40,7 @@ import com.sun.messaging.jmq.resources.SharedResources;
  * a <code>ReqRespListener</code> object or a <code>OnewayListener</code> object, depending on whether the component is
  * written for a request-response style of interaction or for a one-way (asynchronous) style of interaction.
  *
- * @deprecated since 6.2, will be removed without replacement
  */
-@Deprecated
 public abstract class JAXMServlet extends HttpServlet {
     /**
      * 

--- a/mq/src/share/java/examples/jaxm/README
+++ b/mq/src/share/java/examples/jaxm/README
@@ -178,14 +178,14 @@ The servlet examples  - SOAPEchoServlet and SOAPtoJMSServlet - are described bel
 
   - SOAPEchoServlet.java
 
-    The SOAPEchoServlet.java example uses the jakarta.xml.messaging.JAXMServlet
+    The SOAPEchoServlet.java example uses the JAXMServlet
     class to implement a servlet that receives a SOAP messages and echoes a
     SOAP message back as an acknowledgement.
 
 
   - SOAPtoJMSServlet.java
 
-    The SOAPtoJMSServlet.java example uses the jakarta.xml.messaging.JAXMServlet
+    The SOAPtoJMSServlet.java example uses the JAXMServlet
     class to implement a servlet that receives a SOAP message and sends the
     SOAP message using JMS.
     The onMessage() method of the servlet uses the Oracle GlassFish(tm) Server Message 

--- a/mq/src/share/java/examples/jaxm/SOAPEchoServlet.java
+++ b/mq/src/share/java/examples/jaxm/SOAPEchoServlet.java
@@ -11,8 +11,6 @@
 
 import jakarta.servlet.annotation.WebServlet;
 
-import jakarta.xml.messaging.JAXMServlet;
-
 import jakarta.xml.soap.SOAPMessage;
 
 /**

--- a/mq/src/share/java/examples/jaxm/SOAPtoJMSServlet.java
+++ b/mq/src/share/java/examples/jaxm/SOAPtoJMSServlet.java
@@ -9,8 +9,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import jakarta.xml.messaging.JAXMServlet;
-
 import jakarta.xml.soap.SOAPMessage;
 import jakarta.xml.soap.SOAPBody;
 import jakarta.xml.soap.SOAPEnvelope;


### PR DESCRIPTION
This effectively removed (deprecated) JAXMServlet from main code.
Based on #1116.