### PR TITLE
Fix usage of JDK16+ restricted `yield`

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/SessionImpl.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/SessionImpl.java
@@ -2526,7 +2526,7 @@ public class SessionImpl implements JMSRAXASession, Traceable, ContextableSessio
         }
 
         // connection.checkAndSetReconnecting();
-        yield();
+        SessionImpl.yield();
 
         connection.checkReconnecting(null);
 


### PR DESCRIPTION
Fix:
```
Compilation failure
[ERROR] .../SessionImpl.java:[2529,9] invalid use of a restricted identifier 'yield'
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
```