### PR TITLE
Update properties that land in manifests

### DIFF
--- a/mq/src/buildcfg/version.gmk
+++ b/mq/src/buildcfg/version.gmk
@@ -95,12 +95,12 @@ JMQ_BUILD_STR=$(JMQ_PRODUCT_VERSION) (Build $(JMQ_BUILD_NUMBER)-$(JMQ_BUILD_LETT
 # General product information for jar files
 # -----------------------------------------
 
-JMQ_SOFTWARE_NAME=Open Message Queue
-JMQ_SOFTWARE_NAME_JAR=Open Message Queue / Oracle GlassFish(tm) Server Message Queue
-JMQ_SOFTWARE_NAME_BRAND=Oracle GlassFish(tm) Server Message Queue
+JMQ_SOFTWARE_NAME=Eclipse Open Message Queue
+JMQ_SOFTWARE_NAME_JAR=Eclipse Open Message Queue
+JMQ_SOFTWARE_NAME_BRAND=Eclipse Open Message Queue
 JMQ_SOFTWARE_NAME_ABBREV=MQ
 JMQ_SOFTWARE_NAME_ABBREV_LOWERCASE=mq
-JMQ_SOFTWARE_NAME_SHORT=Message Queue
+JMQ_SOFTWARE_NAME_SHORT=Eclipse OpenMQ (tm)
 JMQ_RELEASE_Q_ID=5.1
 
 #
@@ -137,8 +137,8 @@ JMQ_BRAND_JAR_NAME=$(JMQ_SOFTWARE_NAME_JAR) Oracle Brand Product version informa
 JMQ_L10N_JAR_NAME=$(JMQ_SOFTWARE_NAME_JAR) Localizations
 
 # Copyright string ... replace with correct string later
-JMQ_COMPANY_NAME=Oracle
-JMQ_COPYRIGHT_DATE=Copyright (c) 2014, 2017
+JMQ_COMPANY_NAME=Eclipse Foundation
+JMQ_COPYRIGHT_DATE=Copyright (c) 2018, 2021
 JMQ_COPYRIGHT_STR=$(JMQ_COPYRIGHT_DATE), $(JMQ_COMPANY_NAME) and/or its affiliates.  All rights reserved.
 
 # -----------------------------


### PR DESCRIPTION
Example for `imq.jar`:
```diff
--- META-INF/MANIFEST.MF	2021-09-05 13:25:18.042933051 +0200
+++ META-INF/MANIFEST.MF	2021-09-05 13:25:21.621969036 +0200
@@ -1,32 +1,30 @@
 Manifest-Version: 1.0
 Ant-Version: Apache Ant 1.9.14
 Created-By: 11.0.11+9-LTS-194 (Oracle Corporation)
-Specification-Title: Open Message Queue / Oracle GlassFish(tm) Server 
- Message Queue JMS Client
+Specification-Title: Eclipse Open Message Queue JMS Client
 Specification-Version: 6.3.0
-Specification-Vendor:  Oracle
-Implementation-Title: Open Message Queue / Oracle GlassFish(tm) Server
-  Message Queue
+Specification-Vendor:  Eclipse Foundation
+Implementation-Title: Eclipse Open Message Queue
 Implementation-Version: 6.3.0 (Build 1-a)
-Implementation-Vendor: Oracle
+Implementation-Vendor: Eclipse Foundation
 Main-Class: com.sun.messaging.jmq.Version
 Class-Path: jms.jar imqxm.jar imqbrand.jar imq_l10n.jar imq_lang1.jar 
 
 Name: com/sun/messaging
 
 Name: com/sun/messaging/naming
 
 Name: com/sun/messaging/jms
 
 Name: com/sun/messaging/jmq/net
 
 Name: com/sun/messaging/jmq/jmsclient
 
 Name: com/sun/messaging/jmq/auth
 
 Name: com/sun/messaging/jmq/httptunnel
 
 Name: com/sun/messaging/jmq/io
 
 Name: com/sun/messaging/jmq/util

```