### PR TITLE
Fix #1187 to avoid NPE when running imqcmd with authentication using the console.

### DIFF
--- a/mq/main/comm-util/src/main/java/com/sun/messaging/jmq/util/Password.java
+++ b/mq/main/comm-util/src/main/java/com/sun/messaging/jmq/util/Password.java
@@ -42,7 +42,7 @@ public class Password {
             if (console == null) {
                 throw new Exception("Console not available");
             }
-            char[] password = console.readPassword(null);
+            char[] password = console.readPassword();
             if (password == null) {
                 return null;
             }


### PR DESCRIPTION
Fix #1187

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>