### PR TITLE
Fix #214 Add check to validate the value of time-to-live

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageImpl.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageImpl.java
@@ -1470,6 +1470,11 @@ public class MessageImpl implements jakarta.jms.Message, com.sun.messaging.jms.M
 
     @Override
     public void setJMSExpiration(long expiration) throws JMSException {
+        if (expiration < 0) {
+            String errorString = AdministeredObject.cr.getKString(AdministeredObject.cr.X_INVALID_DELIVERY_PARAM, "Expiration", String.valueOf(expiration));
+            JMSException jmse = new JMSException(errorString, AdministeredObject.cr.X_INVALID_DELIVERY_PARAM);
+            ExceptionHandler.throwJMSException(jmse);
+        }
         pkt.setExpiration(expiration);
     }
 

--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageProducerImpl.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageProducerImpl.java
@@ -959,7 +959,7 @@ public class MessageProducerImpl implements MessageProducer {
         }
     }
 
-    protected void checkTimeToLiveValue(long timeToLive) throws JMSException {
+    private static void checkTimeToLiveValue(long timeToLive) throws JMSException {
         if (timeToLive < 0) {
             String errorString = AdministeredObject.cr.getKString(AdministeredObject.cr.X_INVALID_DELIVERY_PARAM, "TimeToLive", String.valueOf(timeToLive));
             ExceptionHandler.throwJMSException(new JMSException(errorString, AdministeredObject.cr.X_INVALID_DELIVERY_PARAM));

--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageProducerImpl.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageProducerImpl.java
@@ -670,6 +670,7 @@ public class MessageProducerImpl implements MessageProducer {
     private void _send(Message message, int deliveryMode, int priority, long timeToLive, CompletionListener completionListener) throws JMSException {
         Message foreignMessage = null;
         checkState();
+        checkTimeToLiveValue(timeToLive);
         if (destination == null) {
             throw new UnsupportedOperationException();
         }
@@ -806,6 +807,7 @@ public class MessageProducerImpl implements MessageProducer {
             throws JMSException {
         Message foreignMessage = null;
         checkState();
+        checkTimeToLiveValue(timeToLive);
         if (destination == null) {
 
             String errorString = AdministeredObject.cr.getKString(AdministeredObject.cr.X_DESTINATION_NOTFOUND, "null");
@@ -954,6 +956,13 @@ public class MessageProducerImpl implements MessageProducer {
                     ExceptionHandler.throwJMSException(new InvalidDestinationException(errorString, AdministeredObject.cr.X_TEMP_DESTINATION_INVALID));
                 }
             }
+        }
+    }
+
+    protected void checkTimeToLiveValue(long timeToLive) throws JMSException {
+        if (timeToLive < 0) {
+            String errorString = AdministeredObject.cr.getKString(AdministeredObject.cr.X_INVALID_DELIVERY_PARAM, "TimeToLive", String.valueOf(timeToLive));
+            ExceptionHandler.throwJMSException(new JMSException(errorString, AdministeredObject.cr.X_INVALID_DELIVERY_PARAM));
         }
     }
 

--- a/mq/main/mq-client/src/test/java/com/sun/messaging/jmq/jmsclient/MessageImplTest.java
+++ b/mq/main/mq-client/src/test/java/com/sun/messaging/jmq/jmsclient/MessageImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jmq.jmsclient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.jms.JMSException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class MessageImplTest {
+    private MessageImpl message;
+
+    @BeforeEach
+    public void setUp() throws JMSException {
+        message = new MessageImpl();
+    }
+
+    @Test
+    void setJMSExpirationToNegativeValShouldThrowJMSEx() throws JMSException {
+        long expiration = -1;
+        assertThatExceptionOfType(jakarta.jms.JMSException.class)
+          .isThrownBy(() -> { message.setJMSExpiration(expiration); })
+          .withMessage("[C4051]: Invalid delivery parameter.  %s : %d", "Expiration", expiration);
+    }
+
+}

--- a/mq/main/mq-client/src/test/java/com/sun/messaging/jmq/jmsclient/MessageProducerImplTest.java
+++ b/mq/main/mq-client/src/test/java/com/sun/messaging/jmq/jmsclient/MessageProducerImplTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jmq.jmsclient;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mock;
+
+import jakarta.jms.CompletionListener;
+import jakarta.jms.JMSException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageProducerImplTest {
+    private MessageProducerImpl messageProducer;
+
+    @Mock
+    private SessionImpl session;
+
+    @Mock
+    private CompletionListener completionListener;
+
+    @BeforeEach
+    public void setUp() throws JMSException {
+        messageProducer = new MessageProducerImpl(session, null);
+    }
+
+    @Test
+    void setTimeToLiveToNegativeValShouldThrowJMSEx() throws JMSException {
+        long timeToLive = -1;
+        assertThatExceptionOfType(jakarta.jms.JMSException.class)
+          .isThrownBy(() -> { messageProducer.setTimeToLive(timeToLive); })
+          .withMessage("[C4051]: Invalid delivery parameter.  %s : %d", "TimeToLive", timeToLive);
+    }
+
+    @Test
+    void sendWithNegativeTimeToLiveShouldThrowJMSEx() throws JMSException {
+        long timeToLive = -1;
+        assertThatExceptionOfType(jakarta.jms.JMSException.class)
+          .isThrownBy(() -> { messageProducer.send(null,0,0,timeToLive,completionListener); })
+          .withMessage("[C4051]: Invalid delivery parameter.  %s : %d", "TimeToLive", timeToLive);
+    }
+
+    @Test
+    void sendToDestWithNegativeTimeToLiveShouldThrowJMSEx() throws JMSException {
+        long timeToLive = -1;
+        assertThatExceptionOfType(jakarta.jms.JMSException.class)
+          .isThrownBy(() -> { messageProducer.send(null,null,0,0,timeToLive,completionListener); })
+          .withMessage("[C4051]: Invalid delivery parameter.  %s : %d", "TimeToLive", timeToLive);
+    }
+
+}

--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/DirectPacket.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/DirectPacket.java
@@ -1264,6 +1264,11 @@ public class DirectPacket implements JMSPacket, jakarta.jms.Message, com.sun.mes
             _loggerJM.fine(_lgrMID_INF + /* "messageId="+messageId+":"+ */
                     "setJMSExpiration()" + expiration);
         }
+        if (expiration < 0) {
+            String errMsg = _lgrMID_EXC + "setJMSExpiration()" + ":Invalid expiration="+ expiration;
+            _loggerJM.severe(errMsg);
+            throw new JMSException(errMsg);
+        }
         this.pkt.setExpiration(expiration);
     }
 

--- a/mq/main/mq-jmsra/jmsra-ra/src/test/java/com/sun/messaging/jms/ra/DirectPacketTest.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/test/java/com/sun/messaging/jms/ra/DirectPacketTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Contributors to Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.messaging.jms.ra;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jakarta.jms.JMSException;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class DirectPacketTest {
+    private DirectPacket directPacket;
+
+    @BeforeEach
+    public void setUp() throws JMSException {
+        directPacket = new DirectPacket(null);
+    }
+
+    @Test
+    void setJMSExpirationToNegativeValShouldThrowJMSEx() throws JMSException {
+        long expiration = -1;
+        assertThatExceptionOfType(jakarta.jms.JMSException.class)
+          .isThrownBy(() -> { directPacket.setJMSExpiration(expiration); })
+          .withMessage("MQJMSRA_DM4001: %s:Invalid expiration=%d", "setJMSExpiration()", expiration);
+    }
+}


### PR DESCRIPTION
* Fixes #214 

The value of time-to-live is validated if it is an argument of MessageProducer$setTimeToLive(), and throws JMSException if the value is less than 0.

https://github.com/eclipse-ee4j/openmq/blob/8f01a203c2a6ca95c1f9bcd2843dc3c7e82aec60/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/MessageProducerImpl.java#L458-L468

However, if the time-to-live is passed as argument of MessageProducer$send(), the value is NOT validated and passed directly to Message$setJMSExpiration().

Jakarta Messaging 3.0 does not define the valid range of time-to-live but negative values are invalid because the value is the duration of time before the message expires.
(\*) [Jakarta Messaging 3.0](https://jakarta.ee/specifications/messaging/3.0/) 7.8. Message time-to-live
(\*) 0 means no limit

This proposal is that MessageProducer$send() and Message$setJMSExpiration() also throw the JMSException when negative time-to-live values are passed.
(\*) Message$setJMSExpiration() is not public to the user, but the validation should be added as well, I think.

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>