### PR TITLE
Fix #1219 autocreate properties affect the default value for physical destinations

### DIFF
--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Destination.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Destination.java
@@ -137,7 +137,7 @@ public abstract class Destination implements DestinationSpi, Serializable, com.s
     protected SizeString memoryLimit = null;
 
     protected int maxConsumerLimit = DestinationList.UNLIMITED;
-    protected int maxProducerLimit = DestinationList.defaultProducerCnt;
+    protected int maxProducerLimit = DestinationList.DEFAULT_MAX_PRODUCERS;
     protected int maxPrefetch = DestinationList.DEFAULT_PREFETCH;
 
     protected transient int producerMsgBatchSize = DestinationList.MAX_PRODUCER_BATCH;
@@ -149,7 +149,7 @@ public abstract class Destination implements DestinationSpi, Serializable, com.s
 
     private transient ProducerFlow producerFlow = new ProducerFlow();
 
-    boolean useDMQ = DestinationList.autocreateUseDMQ;
+    boolean useDMQ = true;
 
     boolean isDMQ = false;
 
@@ -1096,6 +1096,8 @@ public abstract class Destination implements DestinationSpi, Serializable, com.s
                 setByteCapacity(DL.defaultMaxMsgBytes);
                 setMaxByteSize(DL.defaultMaxBytesPerMsg);
                 setLimitBehavior(DL.defaultLimitBehavior);
+                setMaxProducers(DL.defaultProducerCnt);
+                setUseDMQ(DL.autocreateUseDMQ);
                 if (DL.defaultIsLocal) {
                     setScope(DestScope.LOCAL);
                 }

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Topic.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/core/Topic.java
@@ -99,9 +99,8 @@ public class Topic extends Destination {
             throws BrokerException, IOException {
         super(destination, type, store, id, autocreate, dl);
 
-        maxPrefetch = TOPIC_DEFAULT_PREFETCH;
-
         if (autocreate) {
+            maxPrefetch = TOPIC_DEFAULT_PREFETCH;
             maxSharedConsumers = AUTO_MAX_SHARED_CONSUMER_LIMIT;
             sharedPrefetch = AUTO_MAX_SHARED_FLOW_LIMIT;
         } else {


### PR DESCRIPTION
* Fix #1219

I tried to add UnitTests for this changes, but I found it difficult to add UnitTests while maintaining the current implementation because some objects and loggers that require specific property files are initialized with instance variables, causing errors during instantiation in test method.
Do I need to modify the implementation in places not directly related to the issue to be testable? or any other ideas?

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>