### PR TITLE
Fix#216 Exception caused when setting client ID to a Connection created out of ConnectionFactory without ClientID

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ConnectionImpl.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jmq/jmsclient/ConnectionImpl.java
@@ -2361,9 +2361,11 @@ public class ConnectionImpl implements com.sun.messaging.jms.Connection, Traceab
 
     public synchronized void _unsetClientID() throws JMSException {
         // System.out.println("CI:_unsetClientID()");
-        this.clientID = null;
         allowToSetClientID = true;
-        protocolHandler.unsetClientID();
+        if (this.clientID != null) {
+            this.clientID = null;
+            protocolHandler.unsetClientID();
+        }
     }
 
     public synchronized void _setClientID(String cid) throws JMSException {
@@ -2412,10 +2414,8 @@ public class ConnectionImpl implements com.sun.messaging.jms.Connection, Traceab
                 Debug.printStackTrace(e);
             }
         }
-        if (this.clientID != null) {
-            // System.out.println("CI:_closeForPooling:unsettingClientID");
-            _unsetClientID();
-        }
+        // System.out.println("CI:_closeForPooling:unsettingClientID");
+        _unsetClientID();
     }
 
     public void _setExceptionListenerFromRA(ExceptionListener listener) throws JMSException {


### PR DESCRIPTION
This is because the value of allowToSetClientID is not reset to the initial value (true) when closing a connection that is not set ClientID.

Signed-off-by: hs536 <sawamura.hiroki@fujitsu.com>