### PR TITLE
Remove dead code

### DIFF
--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
@@ -261,7 +261,6 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
         File file = null;
         String word = "";
         int ix = 0;
-        boolean sawg = false;
         boolean sawu = false;
         while (ix < pattern.length()) {
             char ch = pattern.charAt(ix);
@@ -300,7 +299,6 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
                     continue;
                 } else if (ch2 == 'g') {
                     word = word + generation;
-                    sawg = true;
                     ix++;
                     continue;
                 } else if (ch2 == 'u') {

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
@@ -263,7 +263,7 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
         int ix = 0;
         boolean sawg = false;
         boolean sawu = false;
-        int count = 1; // no of files to use
+        final int count = 1; // no of files to use
         while (ix < pattern.length()) {
             char ch = pattern.charAt(ix);
             ix++;

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
@@ -316,9 +316,6 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
             }
             word = word + ch;
         }
-        if (false && !sawg) {
-            word = word + "." + generation;
-        }
         if (unique > 0 && !sawu) {
             word = word + "." + unique;
         }

--- a/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
+++ b/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
@@ -263,7 +263,6 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
         int ix = 0;
         boolean sawg = false;
         boolean sawu = false;
-        final int count = 1; // no of files to use
         while (ix < pattern.length()) {
             char ch = pattern.charAt(ix);
             ix++;
@@ -317,7 +316,7 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
             }
             word = word + ch;
         }
-        if (count > 1 && !sawg) {
+        if (false && !sawg) {
             word = word + "." + generation;
         }
         if (unique > 0 && !sawu) {


### PR DESCRIPTION
In [_original_](https://github.com/openjdk/jdk/blob/7b2e99178f7cf41ecd86b2ccfba38ea653e815e7/jdk/src/share/classes/java/util/logging/FileHandler.java#L463-L536), that modified method seems to be transplanted from, `count` was a field.
In upstream it evolved a bit since.