### PR TITLE
Fix javadoc warnings

### DIFF
--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jms/JMSException.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jms/JMSException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -65,7 +65,7 @@ public class JMSException extends jakarta.jms.JMSException implements Loggable {
      *
      * @param reason a description of the exception
      * @param errorCode a string specifying the vendor-specific error code
-     * @param cause the cause. A <tt>null</tt> value is permitted, and indicates that the cause is non-existent or unknown.
+     * @param cause the cause. A <CODE>null</CODE> value is permitted, and indicates that the cause is non-existent or unknown.
      **/
     public JMSException(String reason, String errorCode, Throwable cause) {
         super(reason, errorCode);

--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jms/JMSSecurityException.java
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jms/JMSSecurityException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -56,7 +56,7 @@ public class JMSSecurityException extends jakarta.jms.JMSSecurityException imple
      *
      * @param reason a description of the exception
      * @param errorCode a string specifying the vendor-specific error code
-     * @param cause the cause. A <tt>null</tt> value is permitted, and indicates that the cause is non-existent or unknown.
+     * @param cause the cause. A <CODE>null</CODE> value is permitted, and indicates that the cause is non-existent or unknown.
      **/
     public JMSSecurityException(String reason, String errorCode, Throwable cause) {
         super(reason, errorCode);

--- a/mq/main/mq-client/src/main/java/com/sun/messaging/jms/package.html
+++ b/mq/main/mq-client/src/main/java/com/sun/messaging/jms/package.html
@@ -4,6 +4,7 @@
 <!--
 
     Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,7 +53,7 @@ enable MQ JMS clients to perform finer
 grained error handling than that available with standard
 JMS exceptions.
 
-@see "Jakarta Messaging API"
+<P>See <I>Jakarta Messaging API</I>.</P>
 
 </BODY>
 </HTML>


### PR DESCRIPTION
- unexpected content
- tag not supported in the generated HTML version: tt