### PR TITLE
Bump resource-api

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>jakarta.resource</groupId>
                 <artifactId>jakarta.resource-api</artifactId>
-                <version>2.1.0-RC1</version>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.servlet</groupId>


### PR DESCRIPTION
[2.1.0-RC1 removed from staging](https://www.eclipse.org/lists/jca-dev/msg00068.html)