### PR TITLE
#1431 Fixed ra.xml descriptor for 6.2 releases.

### DIFF
--- a/docs/mq/mq-admin-guide/pom.xml
+++ b/docs/mq/mq-admin-guide/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-admin-guide</artifactId>

--- a/docs/mq/mq-dev-guide-c/pom.xml
+++ b/docs/mq/mq-dev-guide-c/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-dev-guide-c</artifactId>

--- a/docs/mq/mq-dev-guide-java/pom.xml
+++ b/docs/mq/mq-dev-guide-java/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-dev-guide-java</artifactId>

--- a/docs/mq/mq-dev-guide-jmx/pom.xml
+++ b/docs/mq/mq-dev-guide-jmx/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-dev-guide-jmx</artifactId>

--- a/docs/mq/mq-release-notes/pom.xml
+++ b/docs/mq/mq-release-notes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-release-notes</artifactId>

--- a/docs/mq/mq-tech-over/pom.xml
+++ b/docs/mq/mq-tech-over/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-docs</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
     <groupId>org.glassfish</groupId>
     <artifactId>mq-tech-over</artifactId>

--- a/docs/mq/pom.xml
+++ b/docs/mq/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>mq-docs</artifactId>

--- a/mq/distribution/pom.xml
+++ b/mq/distribution/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>mq-distribution</artifactId>
-    <version>6.2.0</version>
+    <version>6.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Message Queue</name>
 

--- a/mq/main/bridge/bridge-admin/pom.xml
+++ b/mq/main/bridge/bridge-admin/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-admin</artifactId>

--- a/mq/main/bridge/bridge-api/pom.xml
+++ b/mq/main/bridge/bridge-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-api</artifactId>

--- a/mq/main/bridge/bridge-jms/pom.xml
+++ b/mq/main/bridge/bridge-jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-jms</artifactId>

--- a/mq/main/bridge/bridge-stomp/pom.xml
+++ b/mq/main/bridge/bridge-stomp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>bridge</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbridge-stomp</artifactId>

--- a/mq/main/bridge/pom.xml
+++ b/mq/main/bridge/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bridge</artifactId>

--- a/mq/main/comm-io/pom.xml
+++ b/mq/main/comm-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-io</artifactId>

--- a/mq/main/comm-util/pom.xml
+++ b/mq/main/comm-util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqcomm-util</artifactId>

--- a/mq/main/http-tunnel/pom.xml
+++ b/mq/main/http-tunnel/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>http-tunnel</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-server/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-server</artifactId>

--- a/mq/main/http-tunnel/tunnel-api-share/pom.xml
+++ b/mq/main/http-tunnel/tunnel-api-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel-api-share</artifactId>

--- a/mq/main/http-tunnel/tunnel/pom.xml
+++ b/mq/main/http-tunnel/tunnel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>http-tunnel</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqhttp-tunnel</artifactId>

--- a/mq/main/jaxm-api/pom.xml
+++ b/mq/main/jaxm-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjaxm-api</artifactId>

--- a/mq/main/logger/pom.xml
+++ b/mq/main/logger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-logger</artifactId>

--- a/mq/main/mq-admin/admin-cli/pom.xml
+++ b/mq/main/mq-admin/admin-cli/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-cli</artifactId>

--- a/mq/main/mq-admin/admin-gui/pom.xml
+++ b/mq/main/mq-admin/admin-gui/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-admin</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqadmin-gui</artifactId>

--- a/mq/main/mq-admin/pom.xml
+++ b/mq/main/mq-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-admin</artifactId>

--- a/mq/main/mq-broker/broker-comm/pom.xml
+++ b/mq/main/mq-broker/broker-comm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-comm</artifactId>

--- a/mq/main/mq-broker/broker-core/pom.xml
+++ b/mq/main/mq-broker/broker-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqbroker-core</artifactId>

--- a/mq/main/mq-broker/cluster/pom.xml
+++ b/mq/main/mq-broker/cluster/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-cluster</artifactId>

--- a/mq/main/mq-broker/partition/persist-api/pom.xml
+++ b/mq/main/mq-broker/partition/persist-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-api</artifactId>

--- a/mq/main/mq-broker/partition/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/partition/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-partition</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpartition-persist-jdbc</artifactId>

--- a/mq/main/mq-broker/partition/pom.xml
+++ b/mq/main/mq-broker/partition/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-partition</artifactId>

--- a/mq/main/mq-broker/persist-file/pom.xml
+++ b/mq/main/mq-broker/persist-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-file</artifactId>

--- a/mq/main/mq-broker/persist-jdbc/pom.xml
+++ b/mq/main/mq-broker/persist-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq-broker</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqpersist-jdbc</artifactId>

--- a/mq/main/mq-broker/pom.xml
+++ b/mq/main/mq-broker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-broker</artifactId>

--- a/mq/main/mq-client/pom.xml
+++ b/mq/main/mq-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-client</artifactId>

--- a/mq/main/mq-direct/pom.xml
+++ b/mq/main/mq-direct/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-direct</artifactId>

--- a/mq/main/mq-jmsra/jmsra-api/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-api</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/pom.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>jmsra</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmsra-ra</artifactId>

--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/ra.xml
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/ra.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2022 Contributors to Eclipse Foundation. All rights reserved.
     Copyright (c) 2000, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -17,16 +18,16 @@
 
 -->
 
-<connector xmlns="http://java.sun.com/xml/ns/j2ee"
+<connector xmlns="https://jakarta.ee/xml/ns/jakartaee"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
-           http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
-           version="1.5">
-    <description>Oracle GlassFish(tm) Server Message Queue JMS Resource Adapter</description>
-    <display-name>Oracle GlassFish(tm) Server Message Queue 5.1 Java EE Resource Adapter for JMS</display-name>
-    <vendor-name>Oracle</vendor-name>
-    <eis-type>Java Message Service v 1.1</eis-type>
-    <resourceadapter-version>5.1</resourceadapter-version>
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           https://jakarta.ee/xml/ns/jakartaee/connector_2_0.xsd"
+           version="2.0">
+    <description>Eclipse OpenMQ(tm) JMS Resource Adapter</description>
+    <display-name>Eclipse OpenMQ(tm) Jakarta EE Resource Adapter for JMS</display-name>
+    <vendor-name>Eclipse Foundation</vendor-name>
+    <eis-type>Jakarta Messaging v 3.0</eis-type>
+    <resourceadapter-version>6.2.1</resourceadapter-version>
 
     <resourceadapter>
         <resourceadapter-class>
@@ -74,7 +75,7 @@
                     <config-property-name>AddressList</config-property-name>
                     <config-property-type>java.lang.String</config-property-type>
                     <config-property-value>localhost</config-property-value>
-                </config-property>                
+                </config-property>
                 <config-property>
                     <config-property-name>UserName</config-property-name>
                     <config-property-type>java.lang.String</config-property-type>
@@ -85,13 +86,13 @@
                     <config-property-type>java.lang.String</config-property-type>
                     <config-property-value>guest</config-property-value>
                 </config-property>
-                <connectionfactory-interface> 
+                <connectionfactory-interface>
                     jakarta.jms.ConnectionFactory
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>
                     com.sun.messaging.jms.ra.ConnectionFactoryAdapter
                 </connectionfactory-impl-class>
-                <connection-interface> 
+                <connection-interface>
                     jakarta.jms.QueueConnection
                 </connection-interface>
                 <connection-impl-class>
@@ -106,7 +107,7 @@
                     <config-property-name>AddressList</config-property-name>
                     <config-property-type>java.lang.String</config-property-type>
                     <config-property-value>localhost</config-property-value>
-                </config-property>                
+                </config-property>
                 <config-property>
                     <config-property-name>UserName</config-property-name>
                     <config-property-type>java.lang.String</config-property-type>
@@ -117,13 +118,13 @@
                     <config-property-type>java.lang.String</config-property-type>
                     <config-property-value>guest</config-property-value>
                 </config-property>
-                <connectionfactory-interface> 
+                <connectionfactory-interface>
                     jakarta.jms.QueueConnectionFactory
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>
                     com.sun.messaging.jms.ra.ConnectionFactoryAdapter
                 </connectionfactory-impl-class>
-                <connection-interface> 
+                <connection-interface>
                     jakarta.jms.QueueConnection
                 </connection-interface>
                 <connection-impl-class>
@@ -149,13 +150,13 @@
                     <config-property-type>java.lang.String</config-property-type>
                     <config-property-value>guest</config-property-value>
                 </config-property>
-                <connectionfactory-interface> 
+                <connectionfactory-interface>
                     jakarta.jms.TopicConnectionFactory
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>
                     com.sun.messaging.jms.ra.ConnectionFactoryAdapter
                 </connectionfactory-impl-class>
-                <connection-interface> 
+                <connection-interface>
                     jakarta.jms.TopicConnection
                 </connection-interface>
                 <connection-impl-class>
@@ -178,7 +179,7 @@
             </reauthentication-support>
         </outbound-resourceadapter>
         <inbound-resourceadapter>
-            <messageadapter>          
+            <messageadapter>
                 <messagelistener>
                     <messagelistener-type>
                         jakarta.jms.MessageListener
@@ -186,7 +187,7 @@
                     <activationspec>
                         <activationspec-class>
                             com.sun.messaging.jms.ra.ActivationSpec
-                        </activationspec-class> 
+                        </activationspec-class>
                         <required-config-property>
                             <config-property-name>
                                 destination
@@ -199,7 +200,7 @@
                         </required-config-property>
                     </activationspec>
                 </messagelistener>
-            </messageadapter>          
+            </messageadapter>
         </inbound-resourceadapter>
         <adminobject>
             <adminobject-interface>jakarta.jms.Queue
@@ -258,4 +259,3 @@
         </adminobject>
     </resourceadapter>
 </connector>
-

--- a/mq/main/mq-jmsra/pom.xml
+++ b/mq/main/mq-jmsra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jmsra</artifactId>

--- a/mq/main/mq-share/pom.xml
+++ b/mq/main/mq-share/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-share</artifactId>

--- a/mq/main/mq-ums/pom.xml
+++ b/mq/main/mq-ums/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-ums</artifactId>

--- a/mq/main/mqjmx-api/pom.xml
+++ b/mq/main/mqjmx-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqjmx-api</artifactId>

--- a/mq/main/packager-opensource/pom.xml
+++ b/mq/main/packager-opensource/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-packager-opensource</artifactId>

--- a/mq/main/persist/disk-io/pom.xml
+++ b/mq/main/persist/disk-io/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mqdisk-io</artifactId>

--- a/mq/main/persist/pom.xml
+++ b/mq/main/persist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>persist</artifactId>

--- a/mq/main/persist/txnlog/pom.xml
+++ b/mq/main/persist/txnlog/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>persist</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-txnlog</artifactId>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/mq/main/portunif/pom.xml
+++ b/mq/main/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>mq</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mq-portunif</artifactId>

--- a/mq/pom.xml
+++ b/mq/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.mq</groupId>
         <artifactId>project</artifactId>
-        <version>6.2.0</version>
+        <version>6.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>main-aggregator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish.mq</groupId>
     <artifactId>project</artifactId>
-    <version>6.2.0</version>
+    <version>6.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>MQ Parent Project</name>


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/openmq/issues/1431
Previous failed validations on GF6, because it still used connector 1.5 xsd.