### PR TITLE
Revert "Bump Java used @ LGTM"

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -17,6 +17,6 @@
 extraction:
   java:
     index:
-      java_version: 17
+      java_version: 11
       build_command: "./mvnw -DskipTests clean package -f mq -pl -main/packager-opensource"
 


### PR DESCRIPTION
I thought that
https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/

![lgtm-17](https://user-images.githubusercontent.com/11896137/164388023-c1ee5162-5600-4463-aaa0-edaf46c418a0.png)


but probably this applies https://help.semmle.com/QL/ql-support/language-support/

![lgtm-16](https://user-images.githubusercontent.com/11896137/164388295-57fa1e82-8a4b-4566-b485-03430282eda0.png)



to free service because
```
[2022-04-20 19:37:31] [build-stdout] [2022-04-20 19:37:31] Java source version 17 detected
[2022-04-20 19:37:31] [build-stdout] [2022-04-20 19:37:31] [WARN] Could not find matching toolchain for source version 17
```