### PR TITLE
Set m-bundle-p supportIncrementalBuild

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -563,6 +563,7 @@
                         <_removeheaders>Bnd-LastModified</_removeheaders>
                         <_reproducible>true</_reproducible>
                     </instructions>
+                    <supportIncrementalBuild>true</supportIncrementalBuild>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
https://felix.apache.org/documentation/_attachments/components/bundle-plugin/manifest-mojo.html#supportIncrementalBuild

> supportIncrementalBuild:
>  When true, manifest generation on incremental builds is supported in IDEs like Eclipse.
>  Please note that the underlying BND library does not support incremental build,
>  which means always the whole manifest and SCR metadata is generated.