### PR TITLE
Activate oss-release to ensure releasability of every module

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,15 @@ jobs:
         distribution: 'temurin'
         java-version: 17
     - name: Build OpenMQ
-      run: ./mvnw --show-version --no-transfer-progress --file mq --define skipTests install
+      run: |
+        ./mvnw \
+          --show-version \
+          --no-transfer-progress \
+          --file mq \
+          --define skipTests \
+          --define gpg.skip \
+          --activate-profiles oss-release \
+          install
 
   smoke:
     name: Smoke Tests ${{ matrix.mq_command }} @ Java ${{ matrix.java_version }}


### PR DESCRIPTION
- this was unblocked by https://github.com/eclipse-ee4j/openmq/pull/1589