### PR TITLE
Explicit management for nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.12.0</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
Override 1.6.8 from parent to avoid:
```
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-list (default-cli) on project project: Execution default-cli of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-list failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-list: java.lang.ExceptionInInitializerError: null [ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
```