### PR TITLE
Fix for 'ordered comparison of pointer with integer zero' error on GCC 11.3.

### DIFF
--- a/mq/src/share/cclient/io/Packet.cpp
+++ b/mq/src/share/cclient/io/Packet.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -1260,7 +1261,6 @@ Packet::setMessageBody(PRUint8 * const msgBodyArg,
 {
   CHECK_OBJECT_VALIDITY();
 
-  ASSERT( msgBodyArg >= reinterpret_cast<PRUint8 *>(0) );
   ASSERT( (msgBodyArg == NULL) == (msgBodySizeArg == 0) );
   resetMsgBody();
   

--- a/mq/src/share/cclient/io/Packet.cpp
+++ b/mq/src/share/cclient/io/Packet.cpp
@@ -1260,7 +1260,7 @@ Packet::setMessageBody(PRUint8 * const msgBodyArg,
 {
   CHECK_OBJECT_VALIDITY();
 
-  ASSERT( msgBodyArg >= 0 );
+  ASSERT( msgBodyArg >= reinterpret_cast<PRUint8 *>(0) );
   ASSERT( (msgBodyArg == NULL) == (msgBodySizeArg == 0) );
   resetMsgBody();
   


### PR DESCRIPTION
This one-liner fixes an `ordered comparison of pointer with integer zero` error when compiling the `cclient` with GCC 11.3. 

GCC 11.3 is the default version of GCC that is installed on Ubuntu 22.04. 

Versions of GCC newer than 11.3 should also trigger the error. 

The fix is backward compatible, having been tested with GCC 9.3.0 as well.   