### PR TITLE
Split starting broker per OS

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -178,7 +178,7 @@ jobs:
         while [ true ]
         do
           grep "Broker .*:7676.*ready" brokerd.log && break
-          sleep 10s
+          sleep 10
         done
     - name: Produce message (ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -160,7 +160,18 @@ jobs:
         name: mq-distribution
     - name: Unpack MQ Distribution
       run: unzip -q -d mq/dist mq.zip
-    - name: Start MQ Broker Daemon
+    - name: Start MQ Broker Daemon (ubuntu)
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      timeout-minutes: 2
+      run: |
+        nohup mq/dist/mq/bin/imqbrokerd -verbose > brokerd.log 2>&1 &
+        while [ true ]
+        do
+          grep "Broker .*:7676.*ready" brokerd.log && break
+          sleep 10s
+        done
+    - name: Start MQ Broker Daemon (macos)
+      if: ${{ matrix.os == 'macos-latest' }}
       timeout-minutes: 2
       run: |
         nohup mq/dist/mq/bin/imqbrokerd -verbose > brokerd.log 2>&1 &


### PR DESCRIPTION
With the upcoming (or even ongoing) changes for _macos-latest_ to be _macos-12_
- https://github.com/actions/runner-images/issues/6384

I expect change to `sleep`:
```
usage: sleep seconds
```
to break this workflow.