### PR TITLE
Drop usage of multiModuleProjectDirectory

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -518,12 +518,6 @@
 
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.3.0</version>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>
                     <version>1.0.2</version>
                     <executions>

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -529,7 +529,7 @@
                     </executions>
                     <configuration>
                         <catalogs>
-                            <catalog>${maven.multiModuleProjectDirectory}/mq/.jakartaee-catalog.xml</catalog>
+                            <catalog>${rootlocation}/mq/.jakartaee-catalog.xml</catalog>
                         </catalogs>
                         <catalogHandling>strict</catalogHandling>
                     </configuration>
@@ -639,7 +639,7 @@
                         <configuration>
                             <analysisCache>true</analysisCache>
                             <rulesets>
-                                <ruleset>${maven.multiModuleProjectDirectory}/mq/.pmd/openmq-pmd-rules.xml</ruleset>
+                                <ruleset>${rootlocation}/mq/.pmd/openmq-pmd-rules.xml</ruleset>
                             </rulesets>
                             <failOnViolation>true</failOnViolation>
                         </configuration>
@@ -693,8 +693,8 @@
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
-                            <includeFilterFile>${maven.multiModuleProjectDirectory}/mq/.spotbugs/spotbugs-filter.xml</includeFilterFile>
-                            <jvmArgs>-Dfindbugs.loadPropertiesFrom=file:///${maven.multiModuleProjectDirectory}/mq/.spotbugs/spotbugs.properties</jvmArgs>
+                            <includeFilterFile>${rootlocation}/mq/.spotbugs/spotbugs-filter.xml</includeFilterFile>
+                            <jvmArgs>-Dfindbugs.loadPropertiesFrom=file://${rootlocation}/mq/.spotbugs/spotbugs.properties</jvmArgs>
                         </configuration>
                         <executions>
                             <execution>
@@ -721,7 +721,7 @@
                                     <goal>check</goal>
                                 </goals>
                                 <configuration>
-                                    <configLocation>${maven.multiModuleProjectDirectory}/mq/.checkstyle/checkstyle.xml</configLocation>
+                                    <configLocation>${rootlocation}/mq/.checkstyle/checkstyle.xml</configLocation>
                                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                                 </configuration>
                             </execution>
@@ -761,7 +761,7 @@
                                     <compilerId>eclipse</compilerId>
                                     <compilerArgument/>
                                     <compilerArgs>
-                                        <arg>-properties</arg><arg>${maven.multiModuleProjectDirectory}/mq/.ecj/ecj.prefs</arg>
+                                        <arg>-properties</arg><arg>${rootlocation}/mq/.ecj/ecj.prefs</arg>
                                     </compilerArgs>
                                     <failOnWarning>true</failOnWarning>
                                 </configuration>
@@ -913,7 +913,7 @@
                             <baseDirectory>${project.basedir}</baseDirectory>
                             <quiet>false</quiet>
                             <ignoreYear>true</ignoreYear>
-                            <excludeFile>${maven.multiModuleProjectDirectory}/mq/main/copyright-exclude</excludeFile>
+                            <excludeFile>${rootlocation}/mq/main/copyright-exclude</excludeFile>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                  <execution>
+                      <id>set-rootlocation</id>
+                      <goals>
+                          <goal>rootlocation</goal>
+                      </goals>
+                  </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -72,6 +72,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.13.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- [MNG-6589](https://issues.apache.org/jira/browse/MNG-6589) (closed, won't fix): implementation detail, private
- [MNG-7038](https://issues.apache.org/jira/browse/MNG-7038) - to be exposed as different property