### PR TITLE
Use JDK21 in build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ 17 ]
+        java_version: [ 21 ]
 
     steps:
     - name: Checkout for build

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -941,20 +941,6 @@
             </dependencies>
         </profile>
         <profile>
-            <id>add-test-dependencies:assertj-core</id>
-            <activation>
-                <file>
-                    <exists>${basedir}/src/test/needs.assertj-core</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.assertj</groupId>
-                    <artifactId>assertj-core</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>add-test-dependencies:mockito-core</id>
             <activation>
                 <file>
@@ -966,6 +952,20 @@
                     <groupId>org.mockito</groupId>
                     <artifactId>mockito-core</artifactId>
                     <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>add-test-dependencies:assertj-core</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/src/test/needs.assertj-core</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Reorder dependencies to let newer bytebuddy from mockito win over assert-j

- closes #1802