### PR TITLE
Revert upload/download actions to v3

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -39,7 +39,7 @@ jobs:
                --file mq \
                package
     - name: Upload MQ Distribution
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: mq-distribution
         retention-days: 1
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Download MQ Distribution
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: mq-distribution
     - name: Extract MQ Distribution


### PR DESCRIPTION
v4 fails with current TCK container:
```
2024-02-17T12:34:13.8966695Z ##[endgroup]
2024-02-17T12:34:13.8992499Z ##[group]Waiting for all services to be ready 2024-02-17T12:34:13.8994351Z ##[endgroup]
2024-02-17T12:34:13.9354195Z ##[group]Run actions/download-artifact@v4 2024-02-17T12:34:13.9354695Z with:
2024-02-17T12:34:13.9355143Z   name: mq-distribution
2024-02-17T12:34:13.9355483Z   merge-multiple: false
2024-02-17T12:34:13.9355875Z   repository: eclipse-ee4j/openmq
2024-02-17T12:34:13.9356340Z   run-id: 7941411604
2024-02-17T12:34:13.9356638Z ##[endgroup]
2024-02-17T12:34:13.9473288Z ##[command]/usr/bin/docker exec  c5059f35d8186c8fda99afec3dd1cdd0a0454e37ae4d572faa7931fd8335e228 sh -c "cat /etc/*release | grep ^ID"
2024-02-17T12:34:14.0808025Z /__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.0809230Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.0810317Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.0811721Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.0812753Z /__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.0813831Z /__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
2024-02-17T12:34:14.1010956Z Stop and remove container: 5b382294c3cb42f2bb597093646b0240_ee4jopenmqtck31020220412T111203Z1_6f46c4
```