### PR TITLE
Revert upload action to v3

### DIFF
--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -72,7 +72,7 @@ jobs:
         echo FAILED_COUNT=`head -2 /tmp/summary.txt | tail -1 | sed 's/.*=\\s\\(.*\\)/\\1/'`
         echo ERROR_COUNT=`head -3 /tmp/summary.txt | tail -1 | sed 's/.*=\\s\\(.*\\)/\\1/'`
     - name: Upload TCK Run Log
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: tck-summary
         retention-days: 1


### PR DESCRIPTION
v4 fails the final step with current TCK container: 
```
2024-02-17T16:50:29.4313002Z ##[group]Run
actions/upload-artifact@v4 2024-02-17T16:50:29.4313374Z with:
2024-02-17T16:50:29.4313592Z   name: tck-summary
2024-02-17T16:50:29.4313853Z   retention-days: 1
2024-02-17T16:50:29.4314126Z   path: /tmp/run.log
/tmp/*.txt

2024-02-17T16:50:29.4314987Z   if-no-files-found: warn
2024-02-17T16:50:29.4328529Z   compression-level: 6
2024-02-17T16:50:29.4328992Z   overwrite: false
2024-02-17T16:50:29.4329370Z ##[endgroup]
2024-02-17T16:50:29.4333163Z ##[command]/usr/bin/docker exec  b3b7893aeb2c5854fdd2d8dcebd33d4b2b1fa8b81bb63573af6f5726d2749123 sh -c "cat /etc/*release | grep ^ID"
2024-02-17T16:50:29.5703443Z /__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
2024-02-17T16:50:29.5705281Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
2024-02-17T16:50:29.5707273Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
2024-02-17T16:50:29.5709126Z /__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
2024-02-17T16:50:29.5710991Z /__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
2024-02-17T16:50:29.5712717Z /__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```