### PR TITLE
Remove unused method and field

### DIFF
--- a/mq/main/comm-io/src/main/java/com/sun/messaging/jmq/io/PacketString.java
+++ b/mq/main/comm-io/src/main/java/com/sun/messaging/jmq/io/PacketString.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
- * Copyright 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,19 +35,6 @@ public class PacketString {
     public static final int DELIVERY_COUNT = 11;
     public static final int LAST = 12;
 
-    private static final String[] names = { "NULL", "JMSDestination", "JMSMessageID", "JMSCorrelationID", "JMSReplyTo", "JMSType", "DestinationClass",
-            "ReplyToClass", "TransacionID", "ProducerID", "DeliveryTime" };
-
-    /**
-     * Return a string description of the specified string type
-     *
-     * @param n Type to return description for
-     */
-    public static String getString(int n) {
-        if (n < 0 || n >= LAST) {
-            return "INVALID_STRING";
-        }
-
-        return names[n] + "(" + n + ")";
+    private PacketString() {
     }
 }


### PR DESCRIPTION
This also _fixes_:
- typo in `TransacionID`
- missing name for `DELIVERY_COUNT`:
```java
PacketString.getString(PacketString.DELIVERY_COUNT)
```
would result in `java.lang.ArrayIndexOutOfBoundsException: Index 11 out of bounds for length 11` 3920dced2ba598afd2e6776cf9b1a56760175df7