### PR TITLE
Combined bumps of rewrite-migrate-java+rewrite-maven-plugin

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -565,7 +565,7 @@
                 <plugin>
                     <groupId>org.openrewrite.maven</groupId>
                     <artifactId>rewrite-maven-plugin</artifactId>
-                    <version>5.34.1</version>
+                    <version>5.35.0</version>
                 </plugin>
 
                 <plugin>
@@ -657,7 +657,7 @@
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-migrate-java</artifactId>
-                        <version>2.18.1</version>
+                        <version>2.19.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>


### PR DESCRIPTION
Bump org.openrewrite.recipe:rewrite-migrate-java from 2.18.1 to 2.19.0

Bumps [org.openrewrite.recipe:rewrite-migrate-java](https://github.com/openrewrite/rewrite-migrate-java) from 2.18.1 to 2.19.0.
- [Release notes](https://github.com/openrewrite/rewrite-migrate-java/releases)
- [Commits](https://github.com/openrewrite/rewrite-migrate-java/compare/v2.18.1...v2.19.0)

---
updated-dependencies:
- dependency-name: org.openrewrite.recipe:rewrite-migrate-java dependency-type: direct:production update-type: version-update:semver-minor ...

Bump org.openrewrite.maven:rewrite-maven-plugin from 5.34.1 to 5.35.0

Bumps [org.openrewrite.maven:rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin) from 5.34.1 to 5.35.0.
- [Release notes](https://github.com/openrewrite/rewrite-maven-plugin/releases)
- [Commits](https://github.com/openrewrite/rewrite-maven-plugin/compare/v5.34.1...v5.35.0)

---
updated-dependencies:
- dependency-name: org.openrewrite.maven:rewrite-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...

---

Combines:
- #1987
- #1988