### PR TITLE
Bump required maven to 3.6.3

### DIFF
--- a/mq/README
+++ b/mq/README
@@ -3,7 +3,7 @@ Build Requirements
 ------------------
 To build this Message Queue source bundle, you will need:
 
-1. Maven 3.5.4  (http://maven.apache.org/download.html)
+1. Maven 3.6.3  (http://maven.apache.org/download.html)
 2. JDK 21 or newer (e.g. https://www.oracle.com/java/technologies/javase-downloads.html)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
                                     <message>You need at least JDK21</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.5.4</version>
+                                    <version>3.6.3</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-clean-plugin:3.4.0:clean (default-clean) on project project: The plugin org.apache.maven.plugins:maven-clean-plugin:3.4.0 requires Maven version 3.6.3
```