### PR TITLE
Fix whitespaces

### DIFF
--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2017 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2022 Contributors to Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2020, 2025 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -275,7 +275,7 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
             }
             builderValue.append(s);
             if (st.hasMoreTokens()){
-                builderValue.append(" ");
+                builderValue.append(' ');
             }
         }
 

--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java
@@ -57,11 +57,30 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
     protected static final String _lgrMID_ERR = _lgrMIDPrefix + "3001: ";
     protected static final String _lgrMID_EXC = _lgrMIDPrefix + "4001: ";
 
-    private static final Set<String> parameterNames;
-
-    static {
-        parameterNames = Set.of("-loglevel", "-save", "-shared", "-debug", "-dbuser", "-dbpassword", "-dbpwd", "-diag", "-name", "-port", "-nobind", "-metrics", "-password", "-pwd", "-ldappassword", "-ldappwd", "-read-stdin", "-passfile", "-backup", "-restore", "-cluster", "-force", "-silent", "-s", "-ttyerrors", "-te", "-tty", "-D", "-varhome", "-jmqvarhome", "-imqhome", "-libhome", "-javahome", "-jrehome", "-bgnd", "-init", "-version", "-v", "-ntservice", "-adminkeyfile", "-help", "-h", "-remove", "-reset", "-upgrade-store-nobackup", "-useRmiRegistry", "-startRmiRegistry", "-rmiRegistryPort", "-activateServices");
-    }
+    private static final Set<String> PARAMETER_NAMES = Set.of(
+            "-debug",
+            "-dbuser",
+            "-dbpassword",
+            "-dbpwd",
+            "-name",
+            "-nobind",
+            "-password",
+            "-pwd",
+            "-ldappassword",
+            "-ldappwd",
+            "-passfile",
+            "-backup",
+            "-restore",
+            "-cluster",
+            "-varhome",
+            "-jmqvarhome",
+            "-imqhome",
+            "-libhome",
+            "-javahome",
+            "-jrehome",
+            "-adminkeyfile",
+            "-reset",
+            "-activateServices");
 
     public EmbeddedBrokerRunner(String brokerInstanceName, String brokerBindAddress, int brokerPort, String brokerHomeDir,
             String brokerLibDir, String brokerVarDir, String brokerJavaDir, String brokerExtraArgs, boolean useJNDIRMIServiceURL, int rmiRegistryPort,
@@ -163,7 +182,7 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
 
     /**
      * Assemble a String[] of broker arguments corresponding to the supplied method arguments
-     * 
+     *
      * @return The String[] of broker arguments
      */
     private String[] assembleBrokerArgs(String brokerInstanceName, int brokerPort, String brokerHomeDir, String brokerLibDir, String brokerVarDir,
@@ -246,7 +265,7 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
         StringBuilder builderValue = new StringBuilder();
         while (st.hasMoreTokens()) {
             String s = st.nextToken();
-            if (parameterNames.contains(s)) {
+            if (PARAMETER_NAMES.contains(s)) {
                 if (!builderValue.isEmpty()) {
                     v.add(builderValue.toString());
                     builderValue.delete(0, builderValue.length());
@@ -254,7 +273,10 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
                 v.add(s);
                 continue;
             }
-            builderValue.append(s + " ");
+            builderValue.append(s);
+            if (st.hasMoreTokens()){
+                builderValue.append(" ");
+            }
         }
 
         if (!builderValue.isEmpty()) {
@@ -264,7 +286,7 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
 
     /**
      * Create the in-JVM broker instance
-     * 
+     *
      * Requires field: brokerType Sets fields: directBroker
      */
     private void createTheInVMBrokerInstance() throws ClassNotFoundException, IllegalAccessException, InstantiationException {
@@ -289,9 +311,9 @@ public class EmbeddedBrokerRunner implements BrokerEventListener {
 
     /**
      * Parse the supplied broker arguments and convert them into a Properties object
-     * 
+     *
      * Requires fields: brokerType, apiDirectBroker or raDirectBroker
-     * 
+     *
      * @param brokerArgs the supplied broker arguments
      * @return a Properties object corresponding to the supplied arguments
      */


### PR DESCRIPTION
Credit to @breakponchito

See https://github.com/payara/Payara/issues/4551

The following block of code process the arguments to prepare the execution of the broker:

[openmq/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java at master · eclipse-ee4j/openmq](https://github.com/eclipse-ee4j/openmq/blob/master/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/blc/EmbeddedBrokerRunner.java#L178) 

the following block:



       if (brokerExtraArgs != null && !("".equals(brokerExtraArgs))) {
            StringTokenizer st = new StringTokenizer(brokerExtraArgs, " ");
            while (st.hasMoreTokens()) {
                String t = st.nextToken();
                v.add(t);
            }
        }
process the brokerArgs and separates considering the delimiter as a white space, that is why when sending the following attribute:



brokerArgs= -jrehome "C:\\Program Files\\Java\\jdk-11.0.12"
is processed as follows:



-jrehome
"C:\\Program
Files\\Java\\jdk-11.0.12"
this is saved on a Vector that is processed after

then the following block of code validates the sequence of parameters. The expected case is waiting the path after the property -jrehome but after the previous separation we have two values after the property:

[openmq/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java at master · eclipse-ee4j/openmq](https://github.com/eclipse-ee4j/openmq/blob/master/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java#L1439) 

that is why the following exception is thrown because the third position is not expected

[openmq/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java at master · eclipse-ee4j/openmq](https://github.com/eclipse-ee4j/openmq/blob/master/mq/main/mq-broker/broker-core/src/main/java/com/sun/messaging/jmq/jmsserver/Broker.java#L1705) 



[2021-10-20T17:49:14.044-0500] [Payara 5.2021.9-SNAPSHOT] [SEVERE] [] [] [tid: _ThreadID=150 _ThreadName=JMS_PROXY_default_JMS_host-kernel(1) SelectorRunner] [timeMillis: 1634770154044] [levelValue: 1000] [[
  java.lang.IllegalArgumentException: unknown option Files\\Java\\jdk-11.0.12"