### PR TITLE
Fix incorrect consumer calculation

### DIFF
--- a/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
+++ b/mq/main/mq-jmsra/jmsra-ra/src/main/java/com/sun/messaging/jms/ra/EndpointConsumer.java
@@ -482,24 +482,6 @@ public class EndpointConsumer implements jakarta.jms.ExceptionListener, com.sun.
                     msgConsumer = xas.createDurableSubscriber((Topic) destination, aSpec.getSubscriptionName(), aSpec.getMessageSelector(), false);
                 } else {
                     msgConsumer = xas.createConsumer(destination, aSpec.getMessageSelector());
-                    // test to see if Queue is enabled for more than one consumer when InClustered true
-                    if (destination instanceof jakarta.jms.Queue && aSpec._isInClusteredContainerSet()) {
-                        // Fail activation if it is not
-                        try {
-                            msgConsumer2 = xas.createConsumer(destination, aSpec.getMessageSelector());
-                            msgConsumer2.close();
-                            msgConsumer2 = null;
-                        } catch (JMSException jmse) {
-                            try {
-                                xac.close();
-                            } catch (JMSException jmsecc) {
-                                // System.out.println("MQRA:EC:closed xac on conn creation exception-"+jmsecc.getMessage());
-                            }
-                            xac = null;
-
-                            throw new NotSupportedException("MQRA:EC:Error clustering multiple consumers on Queue:\n" + jmse.getMessage(), jmse);
-                        }
-                    }
                 }
             }
             msgListener = new MessageListener(this, this.endpointFactory, aSpec);


### PR DESCRIPTION
Credit to @luiseufrasio

The imqcmd utility shipped with Open MQ software in Payara Server has a list destinations command that shows basic statistics of the number of producers, consumers and messages for each destination configured. After a cluster restart, the numbers shown by the command’s output are incorrect on a variable frequency, but close to the actual number to be shown. For example, where the number of consumers is 8 for a specific cluster instance, the number displayed might be 6, 7, 9, 10 