### PR TITLE
Bump rewrite-maven-plugin and rewrite-static-analysis

### DIFF
--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -487,7 +487,7 @@
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>
                         <artifactId>rewrite-static-analysis</artifactId>
-                        <version>1.20.0</version>
+                        <version>1.21.0</version>
                     </dependency>
                     <dependency>
                         <groupId>org.openrewrite.recipe</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
                 <plugin>
                     <groupId>org.openrewrite.maven</groupId>
                     <artifactId>rewrite-maven-plugin</artifactId>
-                    <version>5.45.1</version>
+                    <version>5.46.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-artifact-plugin</artifactId>


### PR DESCRIPTION
Combines into one and
- closes #2211 
- closes #2213 

---

Bumps [org.openrewrite.maven:rewrite-maven-plugin](https://github.com/openrewrite/rewrite-maven-plugin) from 5.45.1 to 5.46.0.
- [Release notes](https://github.com/openrewrite/rewrite-maven-plugin/releases)
- [Commits](https://github.com/openrewrite/rewrite-maven-plugin/compare/v5.45.1...v5.46.0)

---
updated-dependencies:
- dependency-name: org.openrewrite.maven:rewrite-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...

Bump org.openrewrite.recipe:rewrite-static-analysis

Bumps [org.openrewrite.recipe:rewrite-static-analysis](https://github.com/openrewrite/rewrite-static-analysis) from 1.20.0 to 1.21.0.
- [Release notes](https://github.com/openrewrite/rewrite-static-analysis/releases)
- [Commits](https://github.com/openrewrite/rewrite-static-analysis/compare/v1.20.0...v1.21.0)

---
updated-dependencies:
- dependency-name: org.openrewrite.recipe:rewrite-static-analysis dependency-type: direct:production update-type: version-update:semver-minor ...