### PR TITLE
Added Develocity setup

### DIFF
--- a/.github/workflows/analyses.yml
+++ b/.github/workflows/analyses.yml
@@ -49,6 +49,8 @@ jobs:
       if: ${{ matrix.tool == 'javac+error-prone' }}
       run: cp -v .mvn/jvm.config.error-prone .mvn/jvm.config
     - name: Test Maven Build
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       run: |
         if [ ${{ matrix.tool == 'ecj' }} ]
         then
@@ -71,5 +73,6 @@ jobs:
           --file mq/main \
           verify \
           --projects -packager-opensource \
-          --define skipTests=true
+          --define skipTests=true \
+          -Dscan.tag.mq.main
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,9 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Build OpenMQ
-      run: ./mvnw -V -ntp -f mq/main clean package -DskipTests -P staging
+      run: ./mvnw -V -ntp -f mq/main clean package -DskipTests -P staging -Dscan.tag.mq.main
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,9 @@ jobs:
         distribution: 'zulu'
         java-version: ${{ matrix.java_version }}
     - name: Test Maven Build
-      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file mq/main install --define build.letter=g --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}
+      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file mq/main install --define build.letter=g --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT} -Dscan.tag.mq.main
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
     - name: Upload MQ Distribution
       uses: actions/upload-artifact@v4
       with:
@@ -55,7 +57,9 @@ jobs:
         distribution: 'temurin'
         java-version: 21
     - name: Docs Maven Build
-      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file docs install
+      run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file docs install -Dscan.tag.mq.docs
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   build-with-no-staging:
     name: Build with no staging repository, using only central-released artifacts
@@ -70,6 +74,8 @@ jobs:
         distribution: 'temurin'
         java-version: 21
     - name: Build OpenMQ
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       run: |
         ./mvnw \
           --show-version \
@@ -78,6 +84,7 @@ jobs:
           --define skipTests \
           --define gpg.skip \
           --activate-profiles oss-release \
+          -Dscan.tag.mq.main \
           install
 
   smoke:

--- a/.github/workflows/tck.yml
+++ b/.github/workflows/tck.yml
@@ -29,6 +29,8 @@ jobs:
         distribution: 'temurin'
         java-version: 21
     - name: Maven Build
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       run: |
         ./mvnw --show-version \
                --no-transfer-progress \
@@ -37,6 +39,7 @@ jobs:
                --define build.letter=t \
                --define build.number=${GITHUB_REF_NAME}/${GITHUB_SHA}/${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT} \
                --file mq/main \
+               -Dscan.tag.mq.main \
                package
     - name: Upload MQ Distribution
       uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pom.xml.versionsBackup
 ### Other ###
 *.class
 
+/.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>ee4j.openmq</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI']) and isFalse(env['JENKINS_URL'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['CI']) or isTrue(env['JENKINS_URL'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ *******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0/.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************
+-->
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org) as explained in the issue #2268.

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Local and remote caching was left disabled on this PR by design so that the build is not affected by this change.

The build scans of the Eclipse OpenMQ project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse OpenMQ project and all other Eclipse projects.

On this Develocity instance, the Eclipse OpenMQ project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. 

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

This PR will remain a draft until the CI is configured by Eclipse Infra team.

Note: Since this applies changes to the Jenkinsfile and this is coming from an untrusted fork, even after applying the CI configuration, Jenkins will not apply the changed Jenkinsfile for this PR.