### PR TITLE
Bump actions/(download|upload)-artifact from v2 to v4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2021, 2025 Contributors to the Eclipse Foundation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0 which is available at
@@ -37,7 +37,7 @@ jobs:
       run: ./mvnw --show-version --no-transfer-progress --activate-profiles staging --file mq install
     - name: Upload MQ Distribution
       if: ${{ matrix.java_version == 11 }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: mq-distribution
         path: mq/dist/bundles/mq.zip
@@ -113,7 +113,7 @@ jobs:
               -lmqcrt
         done
     - name: Download MQ Distribution
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: mq-distribution
     - name: Unpack MQ Distribution


### PR DESCRIPTION
Fix:
```
Error: This request has been automatically failed because it uses a deprecated version of . Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```