### PR TITLE
Use central-publishing-maven-plugin during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <checksums>required</checksums>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Replace default bindings for `:deploy`.