### PR TITLE
Use PMD:AbstractClassWithoutAbstractMethod

### DIFF
--- a/mq/.pmd/openmq-pmd-rules.xml
+++ b/mq/.pmd/openmq-pmd-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2020, 2024 Contributors to Eclipse Foundation. All rights reserved.
+    Copyright (c) 2020 Contributors to Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
     <description>OpenMQ PMD Rules</description>
 
+    <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" />
     <rule ref="category/java/bestpractices.xml/MissingOverride" />
     <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation" />
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />


### PR DESCRIPTION
> The abstract class does not contain any abstract methods.
> An abstract class suggests an incomplete implementation,
> which is to be completed by subclasses implementing
> the abstract methods.
> If the class is intended to be used as a base class only
> (not to be instantiated directly) a protected constructor
> can be provided to prevent direct instantiation.

- #2679