### PR TITLE
Bump grizzly.version from 4.0.2 to 5.0.1

### DIFF
--- a/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/imq/grizzly/GrizzlyIPService.java
+++ b/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/imq/grizzly/GrizzlyIPService.java
@@ -35,8 +35,8 @@ import org.glassfish.grizzly.ssl.SSLFilter;
 import org.glassfish.grizzly.ssl.SSLEngineConfigurator;
 import org.glassfish.grizzly.threadpool.GrizzlyExecutorService;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.glassfish.grizzly.threadpool.ThreadPoolInfo;
 import org.glassfish.grizzly.threadpool.ThreadPoolProbe;
-import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 
 import com.sun.messaging.jmq.util.GoodbyeReason;
 import com.sun.messaging.jmq.util.ServiceState;
@@ -732,21 +732,21 @@ public class GrizzlyIPService extends IMQService implements GrizzlyService, Noti
         }
 
         @Override
-        public void onThreadPoolStartEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStartEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] started, " + threadPool);
             }
         }
 
         @Override
-        public void onThreadPoolStopEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStopEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] stopped");
             }
         }
 
         @Override
-        public void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread) {
             int cnt = counter.getAndIncrement();
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] thread allocated[" + (++cnt) + "]");
@@ -754,7 +754,7 @@ public class GrizzlyIPService extends IMQService implements GrizzlyService, Noti
         }
 
         @Override
-        public void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread) {
             int cnt = counter.getAndDecrement();
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] thread released[" + (--cnt) + "]");
@@ -762,42 +762,42 @@ public class GrizzlyIPService extends IMQService implements GrizzlyService, Noti
         }
 
         @Override
-        public void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads) {
+        public void onMaxNumberOfThreadsEvent(ThreadPoolInfo threadPool, int maxNumberOfThreads) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] threads max " + maxNumberOfThreads + " reached");
             }
         }
 
         @Override
-        public void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task queue event:" + task);
             }
         }
 
         @Override
-        public void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task dequeue event:" + task);
             }
         }
 
         @Override
-        public void onTaskCompleteEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task complete event:" + task);
             }
         }
 
         @Override
-        public void onTaskQueueOverflowEvent(AbstractThreadPool threadPool) {
+        public void onTaskQueueOverflowEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task queue overflow event");
             }
         }
 
         @Override
-        public void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCancelEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task canceled event");
             }

--- a/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/imq/websocket/WebSocketIPService.java
+++ b/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/service/imq/websocket/WebSocketIPService.java
@@ -43,8 +43,8 @@ import org.glassfish.grizzly.websockets.WebSocketEngine;
 import org.glassfish.grizzly.websockets.WebSocketApplication;
 import org.glassfish.grizzly.threadpool.GrizzlyExecutorService;
 import org.glassfish.grizzly.threadpool.ThreadPoolConfig;
+import org.glassfish.grizzly.threadpool.ThreadPoolInfo;
 import org.glassfish.grizzly.threadpool.ThreadPoolProbe;
-import org.glassfish.grizzly.threadpool.AbstractThreadPool;
 import com.sun.messaging.jmq.util.GoodbyeReason;
 import com.sun.messaging.jmq.util.ServiceState;
 import com.sun.messaging.jmq.util.ServiceType;
@@ -820,21 +820,21 @@ public class WebSocketIPService extends IMQService implements GrizzlyService, No
         }
 
         @Override
-        public void onThreadPoolStartEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStartEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] started, " + threadPool);
             }
         }
 
         @Override
-        public void onThreadPoolStopEvent(AbstractThreadPool threadPool) {
+        public void onThreadPoolStopEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] stopped");
             }
         }
 
         @Override
-        public void onThreadAllocateEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadAllocateEvent(ThreadPoolInfo threadPool, Thread thread) {
             int cnt = counter.getAndIncrement();
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] thread allocated[" + (++cnt) + "]");
@@ -842,7 +842,7 @@ public class WebSocketIPService extends IMQService implements GrizzlyService, No
         }
 
         @Override
-        public void onThreadReleaseEvent(AbstractThreadPool threadPool, Thread thread) {
+        public void onThreadReleaseEvent(ThreadPoolInfo threadPool, Thread thread) {
             int cnt = counter.getAndDecrement();
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] thread released[" + (--cnt) + "]");
@@ -850,42 +850,42 @@ public class WebSocketIPService extends IMQService implements GrizzlyService, No
         }
 
         @Override
-        public void onMaxNumberOfThreadsEvent(AbstractThreadPool threadPool, int maxNumberOfThreads) {
+        public void onMaxNumberOfThreadsEvent(ThreadPoolInfo threadPool, int maxNumberOfThreads) {
             if (DEBUG) {
                 logger.log(logger.INFO, "ThreadPool[" + pname + "] threads max " + maxNumberOfThreads + " reached");
             }
         }
 
         @Override
-        public void onTaskQueueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskQueueEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task queue event:" + task);
             }
         }
 
         @Override
-        public void onTaskDequeueEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskDequeueEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task dequeue event:" + task);
             }
         }
 
         @Override
-        public void onTaskCompleteEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCompleteEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task complete event:" + task);
             }
         }
 
         @Override
-        public void onTaskQueueOverflowEvent(AbstractThreadPool threadPool) {
+        public void onTaskQueueOverflowEvent(ThreadPoolInfo threadPool) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task queue overflow event");
             }
         }
 
         @Override
-        public void onTaskCancelEvent(AbstractThreadPool threadPool, Runnable task) {
+        public void onTaskCancelEvent(ThreadPoolInfo threadPool, Runnable task) {
             if (DEBUG) {
                 logger.log(logger.DEBUGHIGH, "ThreadPool[" + pname + "] task cancel event");
             }

--- a/mq/main/pom.xml
+++ b/mq/main/pom.xml
@@ -83,7 +83,7 @@
         <hk2.version>4.0.1</hk2.version>
         <jakarta-jms.version>3.1.0</jakarta-jms.version>
 
-        <grizzly.version>4.0.2</grizzly.version>
+        <grizzly.version>5.0.1</grizzly.version>
 
         <junit.version>6.0.3</junit.version>
         <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
- previous try: #2809
- includes and closes #3051 
- adapts for changes introduced with eclipse-ee4j/glassfish-grizzly#2271

-----

Bumps `grizzly.version` from 4.0.2 to 5.0.1.

Updates `org.glassfish.grizzly:grizzly-framework` from 4.0.2 to 5.0.1

Updates `org.glassfish.grizzly:grizzly-portunif` from 4.0.2 to 5.0.1

Updates `org.glassfish.grizzly:grizzly-http` from 4.0.2 to 5.0.1

Updates `org.glassfish.grizzly:grizzly-http-server` from 4.0.2 to 5.0.1

Updates `org.glassfish.grizzly:grizzly-websockets` from 4.0.2 to 5.0.1

Updates `org.glassfish.grizzly:grizzly-http-servlet` from 4.0.2 to 5.0.1

---
updated-dependencies:
- dependency-name: org.glassfish.grizzly:grizzly-framework dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.glassfish.grizzly:grizzly-portunif dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.glassfish.grizzly:grizzly-http dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.glassfish.grizzly:grizzly-http-server dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.glassfish.grizzly:grizzly-websockets dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.glassfish.grizzly:grizzly-http-servlet dependency-version: 5.0.1 dependency-type: direct:production update-type: version-update:semver-major ...