### PR TITLE
Update Java API link

### DIFF
--- a/mq/src/buildant/rules.xml
+++ b/mq/src/buildant/rules.xml
@@ -275,7 +275,7 @@
    	  <header><![CDATA[${JMQ_SOFTWARE_NAME_SHORT}, 5.1 API Specification]]></header>
     	  <bottom><![CDATA[<font size="-2"><i>Copyright (c) 2010, 2017 Oracle and/or its affiliates.  All rights reserved.</i></font>]]></bottom>
     	  <tag name="todo" scope="all" description="To do:"/>
-    	  <link href="http://download.oracle.com/javase/6/docs/api/"/>
+    	  <link href="https://docs.oracle.com/en/java/javase/25/docs/api/"/>
     	  <arg value="-notimestamp"/>
 	</javadoc>
 


### PR DESCRIPTION
Avoid error
```
[WARNING]   [javadoc] error: Unexpected redirection for URL http://download.oracle.com/javase/6/docs/api/element-list to https://docs.oracle.com/en/java/javase/26/
```