### PR TITLE
Fix `Conflict: an artifact with this name already exists on the workflow run`

### DIFF
--- a/.github/workflows/integrate-with-ldap.yml
+++ b/.github/workflows/integrate-with-ldap.yml
@@ -243,7 +243,7 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
-        name: broker-logs-ldap-integration
+        name: broker-logs-ldaps-integration
         retention-days: 1
         path: |
           mq-*/brokerd*.log


### PR DESCRIPTION
Surprisingly in
- #3090

it not only did not complain but worked fine with duplicate:
<img width="1175" height="106" alt="image" src="https://github.com/user-attachments/assets/81ad50b9-dd14-44fd-94e0-6f05a778406d" />

But in
- #3095

it refuses now.