### PR TITLE
docs: fix outdated and redirecting URLs across Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The project maintains the following source code repositories
 Before your contribution can be accepted by the project team contributors must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* http://www.eclipse.org/legal/ECA.php
+* https://www.eclipse.org/legal/ECA
 
 Git commit records are required to take a specific form.
 The credentials of the actual author must be used to populate the Author field.
@@ -38,4 +38,4 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 Contact the project developers via the project's "dev" list.
 
-* 
+*

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -18,7 +18,7 @@ source code repository logs.
 
 This program and the accompanying materials are made available under the terms
 of the Eclipse Public License v. 2.0 which is available at
-http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+https://www.eclipse.org/legal/epl-2.0/. This Source Code may also be made
 available under the following Secondary Licenses when the conditions for such
 availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
 General Public License, version 2 with the GNU Classpath Exception which is

--- a/docs/mq-admin-guide/README.md
+++ b/docs/mq-admin-guide/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/docs/mq-dev-guide-c/README.md
+++ b/docs/mq-dev-guide-c/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/docs/mq-dev-guide-java/README.md
+++ b/docs/mq-dev-guide-java/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/docs/mq-dev-guide-jmx/README.md
+++ b/docs/mq-dev-guide-jmx/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/docs/mq-release-notes/README.md
+++ b/docs/mq-release-notes/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/docs/mq-shared-doc-resources/src/main/resources/assets/README.md
+++ b/docs/mq-shared-doc-resources/src/main/resources/assets/README.md
@@ -1,4 +1,4 @@
 # About
 
-The {{site.title}} project contains the [AsciiDoc](http://asciidoc.org/)
+The {{site.title}} project contains the [AsciiDoc](https://asciidoc.org/)
 source code for the ...

--- a/docs/mq-tech-over/README.md
+++ b/docs/mq-tech-over/README.md
@@ -71,7 +71,7 @@ When making a release on GitHub, this zip file should be added to the release.
 ## Links
 
 - [JBake maven plugin documentation](https://github.com/Blazebit/jbake-maven-plugin)
-- [JBake documentation](http://jbake.org/docs/2.5.1)
-- [Freemarker documentation](http://freemarker.org/docs)
-- [AsciiDoc User Guide](http://asciidoc.org/userguide.html)
-- [Asciidoctor quick reference](http://asciidoctor.org/docs/asciidoc-syntax-quick-reference)
+- [JBake documentation](https://jbake.org/docs/)
+- [Freemarker documentation](https://freemarker.apache.org/docs/)
+- [AsciiDoc User Guide](https://asciidoc.org/userguide.html)
+- [Asciidoctor quick reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/mq/NOTICE.md
+++ b/mq/NOTICE.md
@@ -18,7 +18,7 @@ source code repository logs.
 
 This program and the accompanying materials are made available under the terms
 of the Eclipse Public License v. 2.0 which is available at
-http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+https://www.eclipse.org/legal/epl-2.0/. This Source Code may also be made
 available under the following Secondary Licenses when the conditions for such
 availability set forth in the Eclipse Public License v. 2.0 are satisfied: GNU
 General Public License, version 2 with the GNU Classpath Exception which is

--- a/mq/src/share/lib/images/admin/README.md
+++ b/mq/src/share/lib/images/admin/README.md
@@ -1,4 +1,4 @@
-Image files in this directory are originally from Oracle's Java Look and Feel Graphics Repository, 1.0.  More details about this graphics library may be found at the Oracle Technology Network, Java Software Human Interface web-page: http://www.oracle.com/technetwork/java/index-138612.html. The images listed below have been contributed by Oracle under the initial project contribution license ([LICENSE](../../../../../../LICENSE.md))
+Image files in this directory are originally from Oracle's Java Look and Feel Graphics Repository, 1.0.  More details about this graphics library may be found at the Oracle Technology Network, Java Software Human Interface web-page: https://www.oracle.com/technetwork/java/index-138612.html. The images listed below have been contributed by Oracle under the initial project contribution license ([LICENSE](../../../../../../LICENSE.md))
 
 - AboutBox48x.gif
 - Add24.gif


### PR DESCRIPTION
This PR updates outdated and redirecting links in repository Markdown documentation to use canonical HTTPS endpoints and current documentation URLs.

replace legacy http links with canonical https URLs
update Eclipse legal links (ECA, EPL-2.0)
refresh JBake/Freemarker/AsciiDoc/Asciidoctor doc links