### PR TITLE
Remove declaration of native method w/o implementation

### DIFF
--- a/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
+++ b/mq/main/mq-broker/mqbroker-core/src/main/java/com/sun/messaging/jmq/jmsserver/management/mbeans/LogConfig.java
@@ -257,7 +257,7 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
     }
 
     // Generate a filename from a pattern.
-    // Remarks: This method is taken from java.util.io.FileHandler.java to resolve pattern becuase it is not accessible
+    // Remarks: This method is taken from java.util.logging.FileHandler.java to resolve pattern because it is not accessible
     @SuppressWarnings("OrphanedFormatString")
     private static File generate(String pattern, int generation, int unique) throws IOException {
         File file = null;
@@ -291,11 +291,6 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
                     continue;
                 } else if (ch2 == 'h') {
                     file = new File(System.getProperty("user.home"));
-                    if (isSetUID()) {
-                        // Ok, we are in a set UID program. For safety's sake
-                        // we disallow attempts to open files relative to %h.
-                        throw new IOException("can't use %h in set UID program");
-                    }
                     ix++;
                     word = "";
                     continue;
@@ -328,7 +323,4 @@ public class LogConfig extends MQMBeanReadWrite implements ConfigListener {
         }
         return file;
     }
-
-    // Private native method to check if we are in a set UID program.
-    private static native boolean isSetUID();
 }


### PR DESCRIPTION
Current code results in
```
java.lang.UnsatisfiedLinkError: 'boolean com.sun.messaging.jmq.jmsserver.management.mbeans.LogConfig.isSetUID()'
```

logged as

```
[#|2026-08-15T20:47:22.287+0200|WARNING|6.10.0|imq.log.Logger|_ThreadID=43;_ThreadName=RMI TCP Connection(4)-X.X.X.X;|WARNING MBean LogConfig: Problem encountered while getting attribute LogDirectory: javax.management.MBeanException:
javax.management.MBeanException
|#]
```

and visible as *Unavailable*s:

<img width="470" height="132" alt="image" src="https://github.com/user-attachments/assets/3305fef7-6c43-4fb2-a111-5540f7db3e2f" />

While the original file has the same method declared: https://github.com/eclipse-ee4j/openmq/blob/9a9add8825a040565051a09010b29b099c2e7d49/jdk/src/share/classes/java/util/logging/FileHandler.java#L676 or https://github.com/eclipse-ee4j/openmq/blob/890adb6410dab4606a4f26a942aed02fb2f55387/src/java.logging/share/classes/java/util/logging/FileHandler.java#L678 this is completely different one:
- as it resides in different class (Java 8)
- as it resides in even more different class (Java 21): 

The original comment/remark falsely referenced wrong class, as it seems `FileHandler` never was in `java.util.io` (?).

I decided to allow `%h`, as being in setuid, in case `java.io.tmpdir` is unset, seems to be fine for `%t` in branch above.

But in general - all this is probably still wrong. This is doing some discovery which is not attached to anything. The **actual** location, using true `FileHandler`, is calculated somewhere else and the value presented in JMX is just some value that sometimes (true, that probably in most cases) - could match the actual one. (In the case for attached screenshot - attributes in console are *Unavailable*, but `user.home` is successfully used and log file **is** created there with no problem.)