### PR TITLE
Align CodeQL analyze action with init

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,5 +46,5 @@ jobs:
       run: ./mvnw -V -ntp -f mq/main clean package -DskipTests -DskipSBOM
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 


### PR DESCRIPTION
## Summary

- align the CodeQL `analyze` action with the `init` action at v4.37.9
- preserve full commit-SHA pinning for both workflow steps

## Why

The source Dependabot PR updates `init` to v4.37.9 while leaving `analyze` at v4.37.8. The CodeQL job reaches its final analysis step and then fails with:

> Loaded a configuration file for version '4.37.9', but running version '4.37.8'

Both sub-actions come from the same CodeQL Action release and must stay aligned. This also follows the repository's merged v4.37.8 update in #3379, which updated both steps together.

## Verification

- source PR #3388 rechecked at `db96bda55f51afd60432e6be04839f86605019a9`
- `./mvnw -V -ntp -f mq/main -N validate -DskipSBOM` with JDK 25.0.3
- workflow YAML parsed successfully
- both CodeQL steps resolve to `cdf488f595d80d6e07e03d4674febd5ab45fa938`, the peeled v4.37.9 tag commit
- `git diff --check`

## AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):

- `jaipilot-maintainer-intent`
- `jaipilot-fast-execution`
- `jaipilot-review-diff`

Execution profile: gpt-5.6-sol · xhigh · fast
